### PR TITLE
Jrea/react query

### DIFF
--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -2,4 +2,4 @@ export { default as LoginForm } from './components/LoginForm';
 export { default as SignUpForm } from './components/SignUpForm';
 export { default as InstanceTable } from './components/InstanceTable';
 export { NileProvider, useNile } from './context';
-export { default as Queries } from './lib/queries';
+export { default as Queries, useQuery, useMutation } from './lib/queries';

--- a/packages/react/src/lib/UserForm/index.tsx
+++ b/packages/react/src/lib/UserForm/index.tsx
@@ -34,7 +34,7 @@ export default function LoginForm(props: {
         placeholder="Email"
         error={Boolean(errors.Email)}
         helperText={errors.Email && 'This field is required'}
-        {...register('Email', { required: true })}
+        {...register('email', { required: true })}
       />
 
       <TextField
@@ -43,7 +43,7 @@ export default function LoginForm(props: {
         type="password"
         error={Boolean(errors.Password)}
         helperText={errors.Password && 'This field is required'}
-        {...register('Password', { required: true })}
+        {...register('password', { required: true })}
       />
 
       <Button type="submit">{buttonText}</Button>

--- a/packages/react/src/lib/queries/index.tsx
+++ b/packages/react/src/lib/queries/index.tsx
@@ -46,3 +46,6 @@ const queryKeys = {
 };
 
 export default queryKeys;
+
+export { useQuery } from './useQuery';
+export { useMutation } from './useMutation';

--- a/packages/react/src/lib/queries/useMutation/index.ts
+++ b/packages/react/src/lib/queries/useMutation/index.ts
@@ -1,0 +1,72 @@
+import {
+  useMutation as reactUseMutation,
+  UseMutationOptions,
+  UseMutationResult,
+} from '@tanstack/react-query';
+import type { MutationFunction, MutationKey } from '@tanstack/query-core';
+
+export function useMutation<
+  TData = unknown,
+  TError = unknown,
+  TVariables = void,
+  TContext = unknown
+>(
+  options: UseMutationOptions<TData, TError, TVariables, TContext>
+): UseMutationResult<TData, TError, TVariables, TContext>;
+export function useMutation<
+  TData = unknown,
+  TError = unknown,
+  TVariables = void,
+  TContext = unknown
+>(
+  mutationFn: MutationFunction<TData, TVariables>,
+  options?: Omit<
+    UseMutationOptions<TData, TError, TVariables, TContext>,
+    'mutationFn'
+  >
+): UseMutationResult<TData, TError, TVariables, TContext>;
+export function useMutation<
+  TData = unknown,
+  TError = unknown,
+  TVariables = void,
+  TContext = unknown
+>(
+  mutationKey: MutationKey,
+  options?: Omit<
+    UseMutationOptions<TData, TError, TVariables, TContext>,
+    'mutationKey'
+  >
+): UseMutationResult<TData, TError, TVariables, TContext>;
+
+export function useMutation<
+  TData = unknown,
+  TError = unknown,
+  TVariables = void,
+  TContext = unknown
+>(
+  mutationKey: MutationKey,
+  mutationFn?: MutationFunction<TData, TVariables>,
+  options?: Omit<
+    UseMutationOptions<TData, TError, TVariables, TContext>,
+    'mutationKey' | 'mutationFn'
+  >
+): UseMutationResult<TData, TError, TVariables, TContext>;
+export function useMutation<
+  TData = unknown,
+  TError = unknown,
+  TVariables = void,
+  TContext = unknown
+>(
+  arg1:
+    | MutationKey
+    | MutationFunction<TData, TVariables>
+    | UseMutationOptions<TData, TError, TVariables, TContext>,
+  arg2?:
+    | MutationFunction<TData, TVariables>
+    | UseMutationOptions<TData, TError, TVariables, TContext>,
+  arg3?: UseMutationOptions<TData, TError, TVariables, TContext>
+): UseMutationResult<TData, TError, TVariables, TContext> {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore - in react-query, a helper function fixes the type
+  return reactUseMutation(arg1, arg2, arg3);
+}

--- a/packages/react/src/lib/queries/useQuery/index.ts
+++ b/packages/react/src/lib/queries/useQuery/index.ts
@@ -1,0 +1,142 @@
+import {
+  useQuery as reactUseQuery,
+  DefinedUseQueryResult,
+  UseQueryOptions,
+  UseQueryResult,
+} from '@tanstack/react-query';
+import type { QueryFunction, QueryKey } from '@tanstack/query-core';
+
+/**
+ * ripped out of https://github.com/TanStack/query/blob/main/packages/react-query/src/useQuery.ts
+ *
+ */
+export function useQuery<
+  TQueryFnData = unknown,
+  TError = unknown,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey
+>(
+  options: Omit<
+    UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+    'initialData'
+  > & { initialData?: () => undefined }
+): UseQueryResult<TData, TError>;
+
+export function useQuery<
+  TQueryFnData = unknown,
+  TError = unknown,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey
+>(
+  options: Omit<
+    UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+    'initialData'
+  > & { initialData: TQueryFnData | (() => TQueryFnData) }
+): DefinedUseQueryResult<TData, TError>;
+
+export function useQuery<
+  TQueryFnData = unknown,
+  TError = unknown,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey
+>(
+  options: UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>
+): UseQueryResult<TData, TError>;
+
+export function useQuery<
+  TQueryFnData = unknown,
+  TError = unknown,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey
+>(
+  queryKey: TQueryKey,
+  options?: Omit<
+    UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+    'queryKey' | 'initialData'
+  > & { initialData?: () => undefined }
+): UseQueryResult<TData, TError>;
+
+export function useQuery<
+  TQueryFnData = unknown,
+  TError = unknown,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey
+>(
+  queryKey: TQueryKey,
+  options?: Omit<
+    UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+    'queryKey' | 'initialData'
+  > & { initialData: TQueryFnData | (() => TQueryFnData) }
+): DefinedUseQueryResult<TData, TError>;
+
+export function useQuery<
+  TQueryFnData = unknown,
+  TError = unknown,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey
+>(
+  queryKey: TQueryKey,
+  options?: Omit<
+    UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+    'queryKey'
+  >
+): UseQueryResult<TData, TError>;
+
+export function useQuery<
+  TQueryFnData = unknown,
+  TError = unknown,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey
+>(
+  queryKey: TQueryKey,
+  queryFn: QueryFunction<TQueryFnData, TQueryKey>,
+  options?: Omit<
+    UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+    'queryKey' | 'queryFn' | 'initialData'
+  > & { initialData?: () => undefined }
+): UseQueryResult<TData, TError>;
+
+export function useQuery<
+  TQueryFnData = unknown,
+  TError = unknown,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey
+>(
+  queryKey: TQueryKey,
+  queryFn: QueryFunction<TQueryFnData, TQueryKey>,
+  options?: Omit<
+    UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+    'queryKey' | 'queryFn' | 'initialData'
+  > & { initialData: TQueryFnData | (() => TQueryFnData) }
+): DefinedUseQueryResult<TData, TError>;
+
+export function useQuery<
+  TQueryFnData = unknown,
+  TError = unknown,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey
+>(
+  queryKey: TQueryKey,
+  queryFn: QueryFunction<TQueryFnData, TQueryKey>,
+  options?: Omit<
+    UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+    'queryKey' | 'queryFn'
+  >
+): UseQueryResult<TData, TError>;
+
+export function useQuery<
+  TQueryFnData,
+  TError,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey
+>(
+  arg1: TQueryKey | UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+  arg2?:
+    | QueryFunction<TQueryFnData, TQueryKey>
+    | UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+  arg3?: UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>
+): UseQueryResult<TData, TError> {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore - in react-query, a helper function fixes the type
+  return reactUseQuery(arg1, arg2, arg3);
+}


### PR DESCRIPTION
I am not sure what I was thinking... but since the provider is created within nile dev, you need to export the functions from the internal context. It's mostly copy paste to keep the types working.

I think this generally makes it better because you import everything from the same dep now. 