### PR TITLE
feat: acquire latest API changes for auth

### DIFF
--- a/lib/nile/spec/api.yaml
+++ b/lib/nile/spec/api.yaml
@@ -4,7 +4,7 @@ info:
   description: Making SaaS chill.
   contact:
     email: support@thenile.dev
-  version: 0.1-88505fc
+  version: 0.1-4c73989
 servers:
 - url: localhost:8080
 paths:
@@ -904,6 +904,19 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/User'
+  /me/token:
+    get:
+      tags:
+      - users
+      description: Get the auth token for the current authenticated user
+      operationId: token
+      responses:
+        "200":
+          description: The auth token for the authenticated user
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Token'
   /workspaces/{workspace}/users:
     get:
       tags:
@@ -1075,6 +1088,7 @@ components:
           - rule_not_found
           - invalid_entity_schema
           - invalid_id
+          - invalid_action
         message:
           type: string
         statusCode:
@@ -1156,64 +1170,20 @@ components:
               joined: 2022-08-09T10:27:30.956079
             org_02qdS9KPAnG6Pt5XFAomu6:
               joined: 2022-08-03T17:30:00.295581
-    AuthzRuleResource:
-      required:
-      - id
-      - type
+    Resource:
       type: object
       properties:
         id:
           type: string
-          readOnly: true
-        created:
-          type: string
-          format: date-time
-          readOnly: true
-        updated:
-          type: string
-          format: date-time
-          readOnly: true
-        seq:
-          type: integer
-          format: int64
-          readOnly: true
         type:
           type: string
-          readOnly: true
-    AuthzRuleSubject:
-      required:
-      - id
-      - type
-      type: object
-      properties:
-        id:
-          type: string
-          readOnly: true
-        created:
-          type: string
-          format: date-time
-          readOnly: true
-        updated:
-          type: string
-          format: date-time
-          readOnly: true
-        seq:
-          type: integer
-          format: int64
-          readOnly: true
-        type:
-          type: string
-          readOnly: true
-          enum:
-          - user
-          - developer
-          - nile_employee
-        customProperties:
-          type: object
-          additionalProperties:
-            type: object
-        email:
-          type: string
+      description: A subset of properties of any custom instance to authorize against.
+      example:
+        id: inst_123
+        type: cluster
+        properties:
+          region: us-west-2
+          status: running
     Rule:
       required:
       - id
@@ -1244,24 +1214,36 @@ components:
           format: date-time
           readOnly: true
         subject:
-          $ref: '#/components/schemas/AuthzRuleSubject'
+          $ref: '#/components/schemas/Subject'
         resource:
-          $ref: '#/components/schemas/AuthzRuleResource'
+          $ref: '#/components/schemas/Resource'
         actions:
           type: array
           items:
             type: string
+            enum:
+            - deny
+    Subject:
+      type: object
+      properties:
+        id:
+          type: string
+        email:
+          type: string
+      description: A subset of properties of a user to authorize against.
     CreateRuleRequest:
       type: object
       properties:
         subject:
-          $ref: '#/components/schemas/AuthzRuleSubject'
+          $ref: '#/components/schemas/Subject'
         resource:
-          $ref: '#/components/schemas/AuthzRuleResource'
+          $ref: '#/components/schemas/Resource'
         actions:
           type: array
           items:
             type: string
+            enum:
+            - deny
     CreateUserRequest:
       required:
       - email

--- a/lib/nile/src/test/index.test.ts
+++ b/lib/nile/src/test/index.test.ts
@@ -17,6 +17,7 @@ describe('index', () => {
         'entities',
         'workspaces',
         'organizations',
+        'events',
       ]);
       keys.forEach((k) => {
         const props = Object.getOwnPropertyNames(
@@ -34,11 +35,13 @@ describe('index', () => {
           expect(props).toEqual([
             'constructor',
             'acceptInvite',
+            'addUserToOrg',
             'createOrganization',
             'deleteOrganization',
             'getOrganization',
             'listInvites',
             'listOrganizations',
+            'listUsersInOrg',
             'updateOrganization',
           ]);
         }
@@ -51,8 +54,10 @@ describe('index', () => {
             'getEntity',
             'getInstance',
             'getOpenAPI',
+            'instanceEvents',
             'listEntities',
             'listInstances',
+            'listInstancesInWorkspace',
             'updateEntity',
             'updateInstance',
           ]);
@@ -61,7 +66,9 @@ describe('index', () => {
           expect(props).toEqual([
             'constructor',
             'createDeveloper',
+            'developerGoogleOAuthCallback',
             'loginDeveloper',
+            'startDeveloperGoogleOAuth',
             'validateDeveloper',
           ]);
         }
@@ -74,6 +81,7 @@ describe('index', () => {
             'listUsers',
             'loginUser',
             'me',
+            'token',
             'updateUser',
             'validateUser',
           ]);


### PR DESCRIPTION
This change ensures that the generated OpenAPI types allow access to the latest auth changes in the API. (See [#478](https://github.com/TheNileDev/iteru/pull/478) and [#488](https://github.com/TheNileDev/iteru/pull/488).)