### PR TITLE
feat: sample workspace yaml for client generation

### DIFF
--- a/lib/nile/package.json
+++ b/lib/nile/package.json
@@ -47,6 +47,7 @@
     "@size-limit/preset-small-lib": "^8.0.1",
     "@types/jest": "^29.0.0",
     "@types/node": "^18.7.15",
+    "openapi-merge-cli": "^1.3.1",
     "size-limit": "^8.0.1",
     "tsdx": "^0.14.1",
     "tslib": "^2.4.0",

--- a/lib/nile/spec/merged.yaml
+++ b/lib/nile/spec/merged.yaml
@@ -1,0 +1,1769 @@
+openapi: 3.0.3
+info:
+  title: Nile API
+  description: Making SaaS chill.
+  contact:
+    email: support@thenile.dev
+  version: 0.1-7b170ae
+servers:
+  - url: 'localhost:8080'
+paths:
+  /auth/login:
+    post:
+      tags:
+        - developers
+      summary: Log in a developer to nile
+      operationId: loginDeveloper
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: '#/components/schemas/LoginInfo'
+        required: true
+      responses:
+        '200':
+          description: JWT token for authentication
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Token'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /auth/validate:
+    post:
+      tags:
+        - developers
+      summary: Validate a developer token
+      operationId: validateDeveloper
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: '#/components/schemas/Token'
+        required: true
+      responses:
+        '204':
+          description: valid token
+        '400':
+          description: invalid token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /auth/oauth/google/callback:
+    get:
+      tags:
+        - developers
+      summary: Developer Google OAuth flow callback
+      description: >
+        This endpoint is called automatically by Google after the user
+        authenticates successfully.
+
+        It's here for documentation purposes only, and it shouldn't be called
+        directly.
+      operationId: developerGoogleOAuthCallback
+      parameters:
+        - name: code
+          in: query
+          schema:
+            type: string
+        - name: state
+          in: query
+          schema:
+            type: string
+      responses:
+        '200':
+          description: A successful login/signup for a developer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeveloperGoogleOAuthResponse'
+        '302':
+          description: |2
+             A redirect to the specified `redirect_to` URL after a successful
+             login/signup for a developer, if `redirect_to` was provided
+             when calling `/auth/oauth/google`. A response cookie
+             containing the developer's auth credentials will be set.
+  /auth/oauth/google:
+    get:
+      tags:
+        - developers
+      summary: Starts the developer Google OAuth flow
+      operationId: startDeveloperGoogleOAuth
+      parameters:
+        - name: redirect_to
+          in: query
+          description: An optional URL to redirect to after a successful login/signup.
+          schema:
+            type: string
+            format: uri
+      responses:
+        '302':
+          description: >
+            A redirect to Google for the user to authenticate.
+
+            After the user authenticates successfully, you'll be redirected to
+            `/auth/oauth/google/callback`.
+  '/workspaces/{workspace}/auth/login':
+    post:
+      tags:
+        - users
+      summary: Log in a user
+      description: >-
+        Login a user to Nile. This operation returns a JWT token. Most Nile
+        operations require authentication and expect this token in the
+        'Authorization: Bearer <token>' header
+      operationId: loginUser
+      parameters:
+        - $ref: '#/components/parameters/workspace'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LoginInfo'
+        required: true
+      responses:
+        '200':
+          description: JWT token for authentication
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Token'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      x-code-samples:
+        - lang: cURL
+          source: >-
+            curl -X POST https://app.thenile.dev:443/auth/login -H
+            'Content-Type: application/json' -D '{"email": "shaun@colton.demo", 
+            "password": "mycatname"}
+        - lang: JS
+          source: >-
+            import Nile from "@theniledev/js";
+
+            const nile = new Nile({ apiUrl: "http://localhost:8080", workspace:
+            "1" });
+
+
+            const body = {
+              workspace: 56,
+              loginInfo: {
+                email: "shaun@colton.demo",
+                password: "mycatname",
+              },
+            };
+
+
+            nile
+              .loginUser(body)
+              .then((data) => {
+                console.log("API called successfully. Returned data: " + data);
+              })
+              .catch((error: any) => console.error(error));
+  '/workspaces/{workspace}/auth/validate':
+    post:
+      tags:
+        - users
+      summary: Validate a user Token
+      description: >-
+        Validates a user token. Use this when using Nile authentication to
+        validate access to non-Nile resources. See the [Add Authentication
+        Guide](https://nile-docs.vercel.app/docs/current/guides/how-to/add_signup_authn#decorating-the-endpoint)
+        for a full example
+      operationId: validateUser
+      parameters:
+        - $ref: '#/components/parameters/workspace'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Token'
+        required: true
+      responses:
+        '204':
+          description: The token is valid
+        '400':
+          description: The token is invalid
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      x-code-samples:
+        - lang: cURL
+          source: >-
+            curl -X POST https://app.thenile.dev:443/auth/validate  -H
+            'Content-Type: application/json' -D '{"token": "token"}'
+        - lang: JS
+          source: >-
+            import Nile from "@theniledev/js";
+
+
+            const nile = new Nile({ apiUrl: "http://localhost:8080", workspace:
+            "1" });
+
+
+            const body = {
+              workspace: 56,
+              token: { token: "token" },
+            };
+
+
+            nile
+              .validateUserToken(body)
+              .then((data) => {
+                console.log("API called successfully. Returned data: " + data);
+              })
+              .catch((error: any) => console.error(error));
+  '/workspaces/{workspace}/orgs/{org}/authz/rules':
+    get:
+      tags:
+        - authz
+      summary: List all rules
+      operationId: listRules
+      parameters:
+        - $ref: '#/components/parameters/workspace'
+        - name: org
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: A list of all rules in this organization
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Rule'
+    post:
+      tags:
+        - authz
+      summary: Create a new rule
+      description: >-
+        Creates a new authorization rule. Note that once you create an
+        authorization rule your workspace defaults to deny-by-default behavior
+        for all users in all orgs.
+      operationId: createRule
+      parameters:
+        - $ref: '#/components/parameters/workspace'
+        - name: org
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateRuleRequest'
+        required: true
+      responses:
+        '201':
+          description: The newly created rule
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Rule'
+  '/workspaces/{workspace}/orgs/{org}/authz/rules/{ruleId}':
+    get:
+      tags:
+        - authz
+      summary: Get a rule
+      operationId: getRule
+      parameters:
+        - $ref: '#/components/parameters/workspace'
+        - name: org
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: ruleId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: The rule with the specified id
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Rule'
+    put:
+      tags:
+        - authz
+      summary: Update a rule
+      operationId: updateRule
+      parameters:
+        - $ref: '#/components/parameters/workspace'
+        - name: org
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: ruleId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateRuleRequest'
+        required: true
+      responses:
+        '200':
+          description: Updated version of the rule with the specified id
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Rule'
+    delete:
+      tags:
+        - authz
+      summary: Delete a rule
+      operationId: deleteRule
+      parameters:
+        - $ref: '#/components/parameters/workspace'
+        - name: org
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: ruleId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Successful instance deletion
+  /developers:
+    post:
+      tags:
+        - developers
+      summary: Create a developer
+      operationId: createDeveloper
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: '#/components/schemas/CreateUserRequest'
+        required: true
+      responses:
+        '201':
+          description: The newly created developer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+  '/workspaces/{workspace}/entities':
+    get:
+      tags:
+        - entities
+      summary: List all Entities
+      operationId: listEntities
+      parameters:
+        - $ref: '#/components/parameters/workspace'
+      responses:
+        '200':
+          description: list of entities
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Entity'
+    post:
+      tags:
+        - entities
+      summary: Create Entity
+      operationId: createEntity
+      parameters:
+        - $ref: '#/components/parameters/workspace'
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: '#/components/schemas/CreateEntityRequest'
+        required: true
+      responses:
+        '200':
+          description: created entity
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Entity'
+  '/workspaces/{workspace}/entities/{type}':
+    get:
+      tags:
+        - entities
+      summary: Get Entity
+      operationId: getEntity
+      parameters:
+        - $ref: '#/components/parameters/workspace'
+        - name: type
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: the entity with the requested type
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Entity'
+    put:
+      tags:
+        - entities
+      summary: Update an Entity
+      operationId: updateEntity
+      parameters:
+        - $ref: '#/components/parameters/workspace'
+        - name: type
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: '#/components/schemas/UpdateEntityRequest'
+        required: true
+      responses:
+        '200':
+          description: the updated entity
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Entity'
+  '/workspaces/{workspace}/entities/{type}/openapi':
+    get:
+      tags:
+        - entities
+      summary: Get a yaml OpenAPI description of an entity
+      operationId: getOpenAPI
+      parameters:
+        - $ref: '#/components/parameters/workspace'
+        - name: type
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: The yaml OpenAPI description of the specified entity
+          content:
+            application/yaml:
+              schema:
+                type: string
+  '/workspaces/{workspace}/events/{type}':
+    get:
+      tags:
+        - entities
+      summary: Get instance events
+      operationId: instance.events
+      parameters:
+        - $ref: '#/components/parameters/workspace'
+        - name: type
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: seq
+          in: query
+          schema:
+            type: integer
+            format: int64
+            default: 0
+        - name: limit
+          in: query
+          schema:
+            maximum: 20
+            type: integer
+            format: int64
+            default: 20
+      responses:
+        '200':
+          description: Events for the type.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/InstanceEvent'
+  '/workspaces/{workspace}/orgs/{org}/instances/{type}':
+    get:
+      tags:
+        - entities
+      summary: ' List all instances'
+      operationId: listInstances
+      parameters:
+        - $ref: '#/components/parameters/workspace'
+        - name: org
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: type
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: A list of all instances of the specified type under this org
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Instance'
+    post:
+      tags:
+        - entities
+      summary: Create a new Instance
+      operationId: createInstance
+      parameters:
+        - $ref: '#/components/parameters/workspace'
+        - name: org
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: type
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/JsonSchemaInstance'
+        required: true
+      responses:
+        '201':
+          description: The newly created instance
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Instance'
+  '/workspaces/{workspace}/orgs/{org}/instances/{type}/{id}':
+    get:
+      tags:
+        - entities
+      summary: Get an instance
+      operationId: getInstance
+      parameters:
+        - $ref: '#/components/parameters/workspace'
+        - name: org
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: type
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: The instance with the specified id
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Instance'
+    put:
+      tags:
+        - entities
+      summary: Update an instance
+      operationId: updateInstance
+      parameters:
+        - $ref: '#/components/parameters/workspace'
+        - name: org
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: type
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateInstanceRequest'
+        required: true
+      responses:
+        '200':
+          description: The updated instance
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Instance'
+    delete:
+      tags:
+        - entities
+      summary: Delete an instance
+      operationId: deleteInstance
+      parameters:
+        - $ref: '#/components/parameters/workspace'
+        - name: org
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: type
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Successful instance deletion
+  '/workspaces/{workspace}/instances/{type}':
+    get:
+      tags:
+        - entities
+      summary: ' List all instances'
+      operationId: listInstancesInWorkspace
+      parameters:
+        - $ref: '#/components/parameters/workspace'
+        - name: type
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: A list of all instances of the specified type under this workspace
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Instance'
+  '/workspaces/{workspace}/orgs/{org}/invites/{code}/accept':
+    post:
+      tags:
+        - organizations
+      summary: Accept an invite
+      operationId: acceptInvite
+      parameters:
+        - $ref: '#/components/parameters/workspace'
+        - name: org
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: code
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Successful invite acceptance
+  '/workspaces/{workspace}/orgs/{org}/invites':
+    get:
+      tags:
+        - organizations
+      summary: List all Invites
+      operationId: listInvites
+      parameters:
+        - $ref: '#/components/parameters/workspace'
+        - name: org
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: A list of all invites under this org
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Invite'
+  '/workspaces/{workspace}/orgs/{org}/users':
+    get:
+      tags:
+        - organizations
+      summary: List users in an organization
+      operationId: listUsersInOrg
+      parameters:
+        - $ref: '#/components/parameters/workspace'
+        - name: org
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: The users in this organization
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/User'
+    post:
+      tags:
+        - organizations
+      summary: Add a user to an organization
+      operationId: addUserToOrg
+      parameters:
+        - $ref: '#/components/parameters/workspace'
+        - name: org
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: '#/components/schemas/AddUserToOrgRequest'
+        required: true
+      responses:
+        '200':
+          description: The user added to the organization
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+  '/workspaces/{workspace}/orgs':
+    get:
+      tags:
+        - organizations
+      summary: List all Organizations
+      operationId: listOrganizations
+      parameters:
+        - $ref: '#/components/parameters/workspace'
+      responses:
+        '200':
+          description: A list of all orgs under this workspace
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Organization'
+    post:
+      tags:
+        - organizations
+      summary: Create a new organization
+      operationId: createOrganization
+      parameters:
+        - $ref: '#/components/parameters/workspace'
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: '#/components/schemas/CreateOrganizationRequest'
+        required: true
+      responses:
+        '201':
+          description: The newly created organization
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Organization'
+  '/workspaces/{workspace}/orgs/{org}':
+    get:
+      tags:
+        - organizations
+      summary: Get an organization by name
+      operationId: getOrganization
+      parameters:
+        - $ref: '#/components/parameters/workspace'
+        - name: org
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: The org with the specified name under this workspace
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Organization'
+    put:
+      tags:
+        - organizations
+      summary: Update an organization
+      operationId: updateOrganization
+      parameters:
+        - $ref: '#/components/parameters/workspace'
+        - name: org
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: '#/components/schemas/UpdateOrganizationRequest'
+        required: true
+      responses:
+        '200':
+          description: The updated org
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Organization'
+    delete:
+      tags:
+        - organizations
+      summary: Delete an organization by id
+      operationId: deleteOrganization
+      parameters:
+        - $ref: '#/components/parameters/workspace'
+        - name: org
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Successful org deletion
+  /me:
+    get:
+      tags:
+        - users
+      description: Get information about current authenticated user
+      operationId: me
+      responses:
+        '200':
+          description: The currently authenticated user
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+  /me/token:
+    get:
+      tags:
+        - users
+      description: >-
+        Echoes the auth token for the current authenticated user. This operation
+        requires that theauth token is passed either as a Bearer token in the
+        authorization header or as a cookie named 'token'. When both are
+        present, they must match.
+      operationId: token
+      responses:
+        '200':
+          description: The auth token for the current authenticated user
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Token'
+        '401':
+          description: The current user is not authorized to access this resource
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  '/workspaces/{workspace}/users':
+    get:
+      tags:
+        - users
+      summary: List all users for a workspace
+      operationId: listUsers
+      parameters:
+        - $ref: '#/components/parameters/workspace'
+      responses:
+        '200':
+          description: A list of all users under this workspace
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/User'
+    post:
+      tags:
+        - users
+      summary: Create a user
+      operationId: createUser
+      parameters:
+        - $ref: '#/components/parameters/workspace'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateUserRequest'
+        required: true
+      responses:
+        '201':
+          description: The newly created user
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+  '/workspaces/{workspace}/users/{id}':
+    get:
+      tags:
+        - users
+      summary: Get a user by id
+      operationId: getUser
+      parameters:
+        - $ref: '#/components/parameters/workspace'
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: The user with the specified id under this workspace
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+    put:
+      tags:
+        - users
+      summary: Update a user
+      operationId: updateUser
+      parameters:
+        - $ref: '#/components/parameters/workspace'
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: '#/components/schemas/UpdateUserRequest'
+        required: true
+      responses:
+        '200':
+          description: the updated user
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+    delete:
+      tags:
+        - users
+      summary: Delete a user
+      operationId: deleteUser
+      parameters:
+        - $ref: '#/components/parameters/workspace'
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Successful user deletion
+  /workspaces:
+    get:
+      tags:
+        - workspaces
+      summary: List all workspaces
+      operationId: listWorkspaces
+      responses:
+        '200':
+          description: A list of all workspaces
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Workspace'
+    post:
+      tags:
+        - workspaces
+      summary: Create a workspace
+      operationId: createWorkspace
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: '#/components/schemas/CreateWorkspaceRequest'
+        required: true
+      responses:
+        '201':
+          description: The newly created workspace
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Workspace'
+  '/workspaces/{workspace}/instances/athlete':
+    parameters:
+      - $ref: '#/components/parameters/workspaceInPath'
+    get:
+      tags:
+        - athlete
+      operationId: listAthleteInstances
+      summary: Get all Athletes
+      responses:
+        '200':
+          description: List of all Athlete instances
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Athlete'
+    post:
+      tags:
+        - athlete
+      operationId: createAthleteInstance
+      summary: Create a new Athlete
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Athlete'
+      responses:
+        '200':
+          description: Created a new Athlete
+  '/workspaces/{workspaces}/instances/athlete/{id}':
+    parameters:
+      - $ref: '#/components/parameters/workspaceInPath'
+      - $ref: '#/components/parameters/idInPath'
+    get:
+      tags:
+        - athlete
+      operationId: getAthleteInstance
+      summary: Get a single Athlete instance
+      responses:
+        '200':
+          description: A single Athlete instance
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Athlete'
+    put:
+      tags:
+        - athlete
+      operationId: updateAthleteInstance
+      summary: Update a single Athlete instance
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Athlete'
+      responses:
+        '200':
+          description: The updated Athlete
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Athlete'
+    delete:
+      tags:
+        - athlete
+      operationId: deleteAthleteInstance
+      summary: Delete a single Athlete instance
+      responses:
+        '204':
+          description: Successful deletion of the Athlete
+  '/workspaces/{workspace}/orgs/{org}/instances/athlete':
+    parameters:
+      - $ref: '#/components/parameters/workspaceInPath'
+      - $ref: '#/components/parameters/orgInPath'
+    get:
+      tags:
+        - entities
+      summary: List all Athlete instances in an organization
+      operationId: listOrgAthleteInstances
+      responses:
+        '200':
+          description: A list of all instances of the specified type under this org
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Athlete'
+    post:
+      tags:
+        - entities
+      summary: Create a new Athlete instance in an organization
+      operationId: createOrgAthleteInstance
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Athlete'
+        required: true
+      responses:
+        '201':
+          description: The newly created instance
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Instance'
+  '/workspaces/{workspace}/orgs/{org}/instances/athlete/{id}':
+    parameters:
+      - $ref: '#/components/parameters/workspaceInPath'
+      - $ref: '#/components/parameters/orgInPath'
+      - $ref: '#/components/parameters/idInPath'
+    get:
+      tags:
+        - entities
+      summary: Get a single Athlete instance within an Organization
+      operationId: getOrgAthleteInstance
+      responses:
+        '200':
+          description: The instance with the specified id
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Athlete'
+    put:
+      tags:
+        - entities
+      summary: Update a single Athlete instance within an Organization
+      operationId: updateOrgAthleteInstance
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Athlete'
+        required: true
+      responses:
+        '200':
+          description: The updated instance
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Instance'
+    delete:
+      tags:
+        - entities
+      summary: Delete an instance
+      operationId: deleteInstance1
+      responses:
+        '204':
+          description: Successful instance deletion
+  '/workspaces/{workspace}/events/athlete':
+    parameters:
+      - $ref: '#/components/parameters/workspaceInPath'
+    get:
+      tags:
+        - events
+      summary: Get Athlete instance events
+      operationId: athleteInstance.events
+      responses:
+        '200':
+          description: Events for the type.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AthleteEvent'
+components:
+  schemas:
+    Token:
+      required:
+        - token
+      type: object
+      properties:
+        token:
+          type: string
+          description: >-
+            JWT authentication token. Most Nile operations the caller to pass a
+            valid token in Authorization HTTP header using Bearer schema
+          example: >-
+            eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c
+    Error:
+      required:
+        - errorCode
+        - message
+        - statusCode
+      type: object
+      properties:
+        errorCode:
+          type: string
+          enum:
+            - internal_error
+            - bad_request
+            - unauthorized_credentials
+            - user_not_found
+            - org_not_found
+            - workspace_not_found
+            - invite_not_found
+            - duplicate_org_name
+            - duplicate_workspace_name
+            - empty_org_name
+            - empty_workspace_name
+            - duplicate_user_email
+            - user_already_in_org
+            - duplicate_entity_name
+            - entity_not_found
+            - instance_not_found
+            - rule_not_found
+            - invalid_entity_schema
+            - invalid_id
+            - invalid_action
+            - empty_actions
+            - invalid_action_combination
+            - forbidden
+        message:
+          type: string
+        statusCode:
+          type: integer
+          format: int32
+    LoginInfo:
+      required:
+        - email
+        - password
+      type: object
+      properties:
+        email:
+          type: string
+          description: The email of the user we are authenticating
+          format: email
+          example: shaun@colton.demo
+        password:
+          minLength: 1
+          type: string
+          description: The password of the user
+          example: mycatname
+    DeveloperGoogleOAuthResponse:
+      required:
+        - token
+      type: object
+      properties:
+        user:
+          $ref: '#/components/schemas/User'
+        token:
+          type: string
+          description: >-
+            JWT authentication token. Most Nile operations the caller to pass a
+            valid token in Authorization HTTP header using Bearer schema
+          example: >-
+            eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c
+    OrgMembership:
+      type: object
+      properties:
+        joined:
+          type: string
+          format: date-time
+      example:
+        joined: '2022-08-03T17:30:00.295Z'
+    User:
+      required:
+        - email
+        - id
+        - type
+      type: object
+      properties:
+        id:
+          type: string
+          readOnly: true
+        created:
+          type: string
+          format: date-time
+          readOnly: true
+        updated:
+          type: string
+          format: date-time
+          readOnly: true
+        seq:
+          type: integer
+          format: int64
+          readOnly: true
+        type:
+          type: string
+          enum:
+            - user
+            - developer
+            - nile_employee
+        email:
+          type: string
+          format: email
+        org_memberships:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/OrgMembership'
+          example:
+            org_02qaCO8qNEmfpAcomojhLb:
+              joined: '2022-08-09T10:27:30.956Z'
+            org_02qdS9KPAnG6Pt5XFAomu6:
+              joined: '2022-08-03T17:30:00.295Z'
+    Action:
+      type: string
+      description: >-
+        The action to be allowed on the resource if a rule is matched. The
+        `deny` action is a special action that denies all access.
+      enum:
+        - read
+        - write
+        - deny
+    Resource:
+      type: object
+      properties:
+        id:
+          type: string
+        type:
+          type: string
+      description: >-
+        A subset of properties of any custom instance to authorize against. Only
+        exact matching is supported, for now.
+      example:
+        id: inst_123
+        type: cluster
+        properties:
+          region: us-west-2
+          status: running
+    Rule:
+      required:
+        - id
+        - type
+      type: object
+      properties:
+        id:
+          type: string
+          readOnly: true
+        created:
+          type: string
+          format: date-time
+          readOnly: true
+        updated:
+          type: string
+          format: date-time
+          readOnly: true
+        seq:
+          type: integer
+          format: int64
+          readOnly: true
+        type:
+          type: string
+          enum:
+            - rule
+        deleted:
+          type: string
+          format: date-time
+          readOnly: true
+        subject:
+          $ref: '#/components/schemas/Subject'
+        resource:
+          $ref: '#/components/schemas/Resource'
+        actions:
+          uniqueItems: true
+          type: array
+          items:
+            $ref: '#/components/schemas/Action'
+    Subject:
+      type: object
+      properties:
+        id:
+          type: string
+        email:
+          type: string
+      description: >-
+        A subset of properties of a user to authorize against. Only exact
+        matching is supported, for now.
+    CreateRuleRequest:
+      required:
+        - actions
+      type: object
+      properties:
+        subject:
+          $ref: '#/components/schemas/Subject'
+        resource:
+          $ref: '#/components/schemas/Resource'
+        actions:
+          minLength: 1
+          uniqueItems: true
+          type: array
+          description: >-
+            The actions to be allowed on the resource if a rule matches a
+            request. At least one action must be provided and executable actions
+            (i.e: `read`, `write`) cannot be combined with non-executable
+            actions (i.e: `deny`). If multiple rules match a request, rules with
+            a `deny` action take precedence over rules with a `read` action. You
+            can define `deny` rules to make exceptions in your rules that allow
+            access.
+          items:
+            $ref: '#/components/schemas/Action'
+    UpdateRuleRequest:
+      type: object
+      properties:
+        subject:
+          $ref: '#/components/schemas/Subject'
+        resource:
+          $ref: '#/components/schemas/Resource'
+        actions:
+          uniqueItems: true
+          type: array
+          items:
+            $ref: '#/components/schemas/Action'
+    CreateUserRequest:
+      required:
+        - email
+        - password
+      type: object
+      properties:
+        email:
+          type: string
+          format: email
+        password:
+          minLength: 1
+          type: string
+    Entity:
+      required:
+        - id
+        - name
+        - schema
+        - type
+      type: object
+      properties:
+        id:
+          type: string
+          readOnly: true
+        created:
+          type: string
+          format: date-time
+          readOnly: true
+        updated:
+          type: string
+          format: date-time
+          readOnly: true
+        seq:
+          type: integer
+          format: int64
+          readOnly: true
+        type:
+          type: string
+          enum:
+            - entity
+        name:
+          type: string
+          example: clusters
+        schema:
+          $ref: '#/components/schemas/JsonSchema'
+    JsonSchema:
+      type: object
+      description: A JSON Schema
+      example:
+        type: object
+        properties:
+          id:
+            type: string
+          memory:
+            type: integer
+          cpus:
+            type: integer
+    CreateEntityRequest:
+      required:
+        - name
+        - schema
+      type: object
+      properties:
+        name:
+          type: string
+          example: clusters
+        schema:
+          $ref: '#/components/schemas/JsonSchema'
+    UpdateEntityRequest:
+      required:
+        - schema
+      type: object
+      properties:
+        schema:
+          $ref: '#/components/schemas/JsonSchema'
+    Instance:
+      required:
+        - id
+        - properties
+        - type
+      type: object
+      properties:
+        id:
+          type: string
+          readOnly: true
+        created:
+          type: string
+          format: date-time
+          readOnly: true
+        updated:
+          type: string
+          format: date-time
+          readOnly: true
+        seq:
+          type: integer
+          format: int64
+          readOnly: true
+        type:
+          type: string
+          description: The entity type of this instance
+          example: clusters
+        deleted:
+          type: string
+          format: date-time
+          readOnly: true
+        properties:
+          $ref: '#/components/schemas/JsonSchemaInstance'
+    InstanceEvent:
+      required:
+        - timestamp
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int32
+        eventType:
+          type: string
+          enum:
+            - CREATE
+            - UPDATE
+            - DELETE
+        before:
+          $ref: '#/components/schemas/Instance'
+        after:
+          $ref: '#/components/schemas/Instance'
+        timestamp:
+          type: string
+          format: date-time
+    JsonSchemaInstance:
+      type: object
+      description: An *instance* of a JSON Schema
+      example:
+        id: lkc-123
+        memory: 4096
+        cpus: 4
+    UpdateInstanceRequest:
+      required:
+        - properties
+      type: object
+      properties:
+        properties:
+          $ref: '#/components/schemas/JsonSchemaInstance'
+    Invite:
+      required:
+        - code
+        - inviter
+        - org
+        - status
+      type: object
+      properties:
+        code:
+          type: string
+        org:
+          type: string
+        inviter:
+          type: string
+        status:
+          type: string
+          enum:
+            - active
+    AddUserToOrgRequest:
+      required:
+        - email
+      type: object
+      properties:
+        email:
+          type: string
+          format: email
+    Organization:
+      required:
+        - id
+        - name
+        - type
+      type: object
+      properties:
+        id:
+          type: string
+          readOnly: true
+        created:
+          type: string
+          format: date-time
+          readOnly: true
+        updated:
+          type: string
+          format: date-time
+          readOnly: true
+        seq:
+          type: integer
+          format: int64
+          readOnly: true
+        type:
+          type: string
+          enum:
+            - nile
+            - organization
+            - workspace
+        name:
+          type: string
+    CreateOrganizationRequest:
+      required:
+        - name
+      type: object
+      properties:
+        name:
+          minLength: 1
+          type: string
+    UpdateOrganizationRequest:
+      required:
+        - name
+      type: object
+      properties:
+        name:
+          minLength: 1
+          type: string
+    UpdateUserRequest:
+      required:
+        - email
+        - password
+      type: object
+      properties:
+        email:
+          type: string
+          format: email
+        password:
+          minLength: 1
+          type: string
+    Workspace:
+      required:
+        - id
+        - name
+        - type
+      type: object
+      properties:
+        id:
+          type: string
+          readOnly: true
+        created:
+          type: string
+          format: date-time
+          readOnly: true
+        updated:
+          type: string
+          format: date-time
+          readOnly: true
+        seq:
+          type: integer
+          format: int64
+          readOnly: true
+        type:
+          type: string
+          enum:
+            - workspace
+        name:
+          type: string
+    CreateWorkspaceRequest:
+      required:
+        - name
+      type: object
+      properties:
+        name:
+          type: string
+    Athlete:
+      allOf:
+        - $ref: 'https://prod.thenile.dev/openapi.yaml#/components/schemas/Instance'
+        - type: object
+          required:
+            - team
+            - jersey
+          properties:
+            type:
+              type: string
+              enum:
+                - athlete
+            properties:
+              type: object
+              required:
+                - team
+                - jersey
+              properties:
+                team:
+                  type: string
+                jersey:
+                  type: integer
+                position:
+                  type: string
+    AthleteEvent:
+      allOf:
+        - $ref: >-
+            https://prod.thenile.dev/openapi.yaml#/components/schemas/InstanceEvent
+        - type: object
+          properties:
+            before:
+              $ref: '#/components/schemas/Athlete'
+            after:
+              $ref: '#/components/schemas/Athlete'
+  parameters:
+    workspace:
+      name: workspace
+      in: path
+      description: >-
+        The name of the Nile workspace where all the data-plane metadata for
+        this user is stored
+      required: true
+      schema:
+        minLength: 1
+        type: string
+    orgIdInQuery:
+      in: query
+      name: orgId
+      schema:
+        type: integer
+      required: true
+      description: Org ID
+    idInPath:
+      in: path
+      name: id
+      schema:
+        type: integer
+      required: true
+      description: Unique identifier
+    typeInPath:
+      in: path
+      name: type
+      schema:
+        type: string
+      required: true
+      description: Entity type
+    workspaceInPath:
+      name: workspace
+      in: path
+      description: The name of the Nile workspace
+      required: true
+      schema:
+        minLength: 1
+        type: string

--- a/lib/nile/spec/openapi-merge.yaml
+++ b/lib/nile/spec/openapi-merge.yaml
@@ -1,0 +1,4 @@
+inputs:
+  - inputFile: api.yaml
+  - inputFile: workspace.yaml
+output: ./merged.yaml

--- a/lib/nile/spec/workspace.yaml
+++ b/lib/nile/spec/workspace.yaml
@@ -1,0 +1,248 @@
+openapi: 3.0.2
+info:
+  title: nile
+  version: '0.1'
+servers:
+- url: 'https://api.thenile.dev/v0'
+paths:
+  /workspaces/{workspace}/instances/athlete:
+    parameters:
+    - $ref: '#/components/parameters/workspaceInPath'
+    get:
+      tags:
+      - athlete
+      operationId: listAthleteInstances
+      summary: Get all Athletes
+      responses:
+        '200':
+          description: List of all Athlete instances
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Athlete'
+    post:
+      tags:
+      - athlete
+      operationId: createAthleteInstance
+      summary: Create a new Athlete
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Athlete'
+      responses:
+        '200':
+          description: Created a new Athlete
+
+  /workspaces/{workspaces}/instances/athlete/{id}:
+    parameters:
+    - $ref: '#/components/parameters/workspaceInPath'
+    - $ref: '#/components/parameters/idInPath'
+    get:
+      tags:
+      - athlete
+      operationId: getAthleteInstance
+      summary: Get a single Athlete instance
+      responses:
+        '200':
+          description: A single Athlete instance
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Athlete'
+    put:
+      tags:
+      - athlete
+      operationId: updateAthleteInstance
+      summary: Update a single Athlete instance
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Athlete'
+      responses:
+        '200':
+          description: The updated Athlete
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Athlete'
+    delete:
+      tags:
+      - athlete
+      operationId: deleteAthleteInstance
+      summary: Delete a single Athlete instance
+      responses:
+        204:
+          description: Successful deletion of the Athlete
+
+  /workspaces/{workspace}/orgs/{org}/instances/athlete:
+    parameters:
+    - $ref: '#/components/parameters/workspaceInPath'
+    - $ref: '#/components/parameters/orgInPath'
+    get:
+      tags:
+      - entities
+      summary: List all Athlete instances in an organization
+      operationId: listOrgAthleteInstances
+      responses:
+        "200":
+          description: A list of all instances of the specified type under this org
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Athlete'
+    post:
+      tags:
+      - entities
+      summary: Create a new Athlete instance in an organization
+      operationId: createOrgAthleteInstance
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Athlete'
+        required: true
+      responses:
+        "201":
+          description: The newly created instance
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Instance'
+
+  /workspaces/{workspace}/orgs/{org}/instances/athlete/{id}:
+    parameters:
+    - $ref: '#/components/parameters/workspaceInPath'
+    - $ref: '#/components/parameters/orgInPath'
+    - $ref: '#/components/parameters/idInPath'
+    get:
+      tags:
+      - entities
+      summary: Get a single Athlete instance within an Organization
+      operationId: getOrgAthleteInstance
+      responses:
+        "200":
+          description: The instance with the specified id
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Athlete'
+    put:
+      tags:
+      - entities
+      summary: Update a single Athlete instance within an Organization
+      operationId: updateOrgAthleteInstance
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Athlete'
+        required: true
+      responses:
+        "200":
+          description: The updated instance
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Instance'
+    delete:
+      tags:
+      - entities
+      summary: Delete an instance
+      operationId: deleteInstance
+      responses:
+        "204":
+          description: Successful instance deletion
+
+  /workspaces/{workspace}/events/athlete:
+    parameters:
+    - $ref: '#/components/parameters/workspaceInPath'
+    get:
+      tags:
+      - events
+      summary: Get Athlete instance events
+      operationId: athleteInstance.events
+      responses:
+        "200":
+          description: Events for the type.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AthleteEvent'
+
+components:
+  parameters:
+    orgIdInQuery:
+      in: query
+      name: orgId
+      schema:
+        type: integer
+      required: true
+      description: Org ID
+    idInPath:
+      in: path
+      name: id
+      schema:
+        type: integer
+      required: true
+      description: Unique identifier
+    typeInPath:
+      in: path
+      name: type
+      schema:
+        type: string
+      required: true
+      description: Entity type
+    workspaceInPath:
+      name: workspace
+      in: path
+      description: The name of the Nile workspace
+      required: true
+      schema:
+        minLength: 1
+        type: string
+
+  schemas:
+    Athlete:
+      allOf:
+      - $ref: 'https://prod.thenile.dev/openapi.yaml#/components/schemas/Instance'
+      - type: object
+        required:
+        - "team"
+        - "jersey"
+        properties:
+          type:
+            type: string
+            enum:
+            - athlete
+          properties:
+            type: object
+            required:
+            - "team"
+            - "jersey"
+            properties:
+              team:
+                type: "string"
+              jersey:
+                type: "integer"
+              position:
+                type: "string"
+
+    AthleteEvent:
+      allOf:
+      - $ref: 'https://prod.thenile.dev/openapi.yaml#/components/schemas/InstanceEvent'
+      - type: object
+        properties:
+          before:
+            $ref: '#/components/schemas/Athlete'
+          after:
+            $ref: '#/components/schemas/Athlete'

--- a/yarn.lock
+++ b/yarn.lock
@@ -32,6 +32,11 @@
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.18.13.tgz#6aff7b350a1e8c3e40b029e46cbe78e24a913483"
   integrity sha512-5yUzC5LqyTFp2HLmDoxGQelcdYgSpP9xsnMWBphAscOdFrHSAVbLNzWiy32sVNDqJRDiJK6klfDnAgu6PAGSHw==
 
+"@babel/compat-data@^7.19.0":
+  version "7.19.0"
+  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.19.0.tgz#2a592fd89bacb1fcde68de31bee4f2f2dacb0e86"
+  integrity sha512-y5rqgTTPTmaF5e2nVhOxw+Ur9HDJLsWb6U/KpgUzRZEdPfE6VOubXBKLdbcUTijzRptednSBDQbYZBOSqJxpJw==
+
 "@babel/core@7.12.9":
   version "7.12.9"
   resolved "https://registry.npmjs.org/@babel/core/-/core-7.12.9.tgz"
@@ -54,7 +59,7 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/core@^7.1.0", "@babel/core@^7.12.10", "@babel/core@^7.12.3", "@babel/core@^7.16.0", "@babel/core@^7.18.10", "@babel/core@^7.4.4", "@babel/core@^7.7.5":
+"@babel/core@^7.1.0", "@babel/core@^7.12.10", "@babel/core@^7.12.3", "@babel/core@^7.16.0", "@babel/core@^7.4.4", "@babel/core@^7.7.5":
   version "7.18.13"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.18.13.tgz#9be8c44512751b05094a4d3ab05fc53a47ce00ac"
   integrity sha512-ZisbOvRRusFktksHSG6pjj1CSvkPkcZq/KHD45LAkVP/oiHJkNBZWfpvlLmX8OtHDG8IuzsFlVRWo08w7Qxn0A==
@@ -69,6 +74,27 @@
     "@babel/template" "^7.18.10"
     "@babel/traverse" "^7.18.13"
     "@babel/types" "^7.18.13"
+    convert-source-map "^1.7.0"
+    debug "^4.1.0"
+    gensync "^1.0.0-beta.2"
+    json5 "^2.2.1"
+    semver "^6.3.0"
+
+"@babel/core@^7.19.0":
+  version "7.19.0"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.19.0.tgz#d2f5f4f2033c00de8096be3c9f45772563e150c3"
+  integrity sha512-reM4+U7B9ss148rh2n1Qs9ASS+w94irYXga7c2jaQv9RVzpS7Mv1a9rnYYwuDa45G+DkORt9g6An2k/V4d9LbQ==
+  dependencies:
+    "@ampproject/remapping" "^2.1.0"
+    "@babel/code-frame" "^7.18.6"
+    "@babel/generator" "^7.19.0"
+    "@babel/helper-compilation-targets" "^7.19.0"
+    "@babel/helper-module-transforms" "^7.19.0"
+    "@babel/helpers" "^7.19.0"
+    "@babel/parser" "^7.19.0"
+    "@babel/template" "^7.18.10"
+    "@babel/traverse" "^7.19.0"
+    "@babel/types" "^7.19.0"
     convert-source-map "^1.7.0"
     debug "^4.1.0"
     gensync "^1.0.0-beta.2"
@@ -93,6 +119,15 @@
     "@jridgewell/gen-mapping" "^0.3.2"
     jsesc "^2.5.1"
 
+"@babel/generator@^7.19.0":
+  version "7.19.0"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.19.0.tgz#785596c06425e59334df2ccee63ab166b738419a"
+  integrity sha512-S1ahxf1gZ2dpoiFgA+ohK9DIpz50bJ0CWs7Zlzb54Z4sG8qmdIrGrVqmy1sAtTVRb+9CU6U8VqT9L0Zj7hxHVg==
+  dependencies:
+    "@babel/types" "^7.19.0"
+    "@jridgewell/gen-mapping" "^0.3.2"
+    jsesc "^2.5.1"
+
 "@babel/helper-annotate-as-pure@^7.18.6":
   version "7.18.6"
   resolved "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.18.6.tgz"
@@ -114,6 +149,16 @@
   integrity sha512-tzLCyVmqUiFlcFoAPLA/gL9TeYrF61VLNtb+hvkuVaB5SUjW7jcfrglBIX1vUIoT7CLP3bBlIMeyEsIl2eFQNg==
   dependencies:
     "@babel/compat-data" "^7.18.8"
+    "@babel/helper-validator-option" "^7.18.6"
+    browserslist "^4.20.2"
+    semver "^6.3.0"
+
+"@babel/helper-compilation-targets@^7.19.0":
+  version "7.19.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.19.0.tgz#537ec8339d53e806ed422f1e06c8f17d55b96bb0"
+  integrity sha512-Ai5bNWXIvwDvWM7njqsG3feMlL9hCVQsPYXodsZyLwshYkZVJt59Gftau4VrE8S9IT9asd2uSP1hG6wCNw+sXA==
+  dependencies:
+    "@babel/compat-data" "^7.19.0"
     "@babel/helper-validator-option" "^7.18.6"
     browserslist "^4.20.2"
     semver "^6.3.0"
@@ -199,6 +244,14 @@
     "@babel/template" "^7.18.6"
     "@babel/types" "^7.18.9"
 
+"@babel/helper-function-name@^7.19.0":
+  version "7.19.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.19.0.tgz#941574ed5390682e872e52d3f38ce9d1bef4648c"
+  integrity sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==
+  dependencies:
+    "@babel/template" "^7.18.10"
+    "@babel/types" "^7.19.0"
+
 "@babel/helper-hoist-variables@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz#d4d2c8fb4baeaa5c68b99cc8245c56554f926678"
@@ -233,6 +286,20 @@
     "@babel/template" "^7.18.6"
     "@babel/traverse" "^7.18.9"
     "@babel/types" "^7.18.9"
+
+"@babel/helper-module-transforms@^7.19.0":
+  version "7.19.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.19.0.tgz#309b230f04e22c58c6a2c0c0c7e50b216d350c30"
+  integrity sha512-3HBZ377Fe14RbLIA+ac3sY4PTgpxHVkFrESaWhoI5PuyXPBBX8+C34qblV9G89ZtycGJCmCI/Ut+VUDK4bltNQ==
+  dependencies:
+    "@babel/helper-environment-visitor" "^7.18.9"
+    "@babel/helper-module-imports" "^7.18.6"
+    "@babel/helper-simple-access" "^7.18.6"
+    "@babel/helper-split-export-declaration" "^7.18.6"
+    "@babel/helper-validator-identifier" "^7.18.6"
+    "@babel/template" "^7.18.10"
+    "@babel/traverse" "^7.19.0"
+    "@babel/types" "^7.19.0"
 
 "@babel/helper-optimise-call-expression@^7.18.6":
   version "7.18.6"
@@ -327,6 +394,15 @@
     "@babel/traverse" "^7.18.9"
     "@babel/types" "^7.18.9"
 
+"@babel/helpers@^7.19.0":
+  version "7.19.0"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.19.0.tgz#f30534657faf246ae96551d88dd31e9d1fa1fc18"
+  integrity sha512-DRBCKGwIEdqY3+rPJgG/dKfQy9+08rHIAJx8q2p+HSWP87s2HCrQmaAMMyMll2kIXKCW0cO1RdQskx15Xakftg==
+  dependencies:
+    "@babel/template" "^7.18.10"
+    "@babel/traverse" "^7.19.0"
+    "@babel/types" "^7.19.0"
+
 "@babel/highlight@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.18.6.tgz#81158601e93e2563795adcbfbdf5d64be3f2ecdf"
@@ -340,6 +416,11 @@
   version "7.18.13"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.18.13.tgz#5b2dd21cae4a2c5145f1fbd8ca103f9313d3b7e4"
   integrity sha512-dgXcIfMuQ0kgzLB2b9tRZs7TTFFaGM2AbtA4fJgUUYukzGH4jwsS7hzQHEGs67jdehpm22vkgKwvbU+aEflgwg==
+
+"@babel/parser@^7.19.0":
+  version "7.19.0"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.19.0.tgz#497fcafb1d5b61376959c1c338745ef0577aa02c"
+  integrity sha512-74bEXKX2h+8rrfQUfsBfuZZHzsEs6Eql4pqy/T4Nn6Y9wNPggQOqD6z6pn5Bl8ZfysKouFZT/UXEH94ummEeQw==
 
 "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@^7.18.6":
   version "7.18.6"
@@ -1167,10 +1248,35 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
+"@babel/traverse@^7.19.0":
+  version "7.19.0"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.19.0.tgz#eb9c561c7360005c592cc645abafe0c3c4548eed"
+  integrity sha512-4pKpFRDh+utd2mbRC8JLnlsMUii3PMHjpL6a0SZ4NMZy7YFP9aXORxEhdMVOc9CpWtDF09IkciQLEhK7Ml7gRA==
+  dependencies:
+    "@babel/code-frame" "^7.18.6"
+    "@babel/generator" "^7.19.0"
+    "@babel/helper-environment-visitor" "^7.18.9"
+    "@babel/helper-function-name" "^7.19.0"
+    "@babel/helper-hoist-variables" "^7.18.6"
+    "@babel/helper-split-export-declaration" "^7.18.6"
+    "@babel/parser" "^7.19.0"
+    "@babel/types" "^7.19.0"
+    debug "^4.1.0"
+    globals "^11.1.0"
+
 "@babel/types@^7.0.0", "@babel/types@^7.12.11", "@babel/types@^7.12.7", "@babel/types@^7.18.10", "@babel/types@^7.18.13", "@babel/types@^7.18.6", "@babel/types@^7.18.9", "@babel/types@^7.2.0", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.4", "@babel/types@^7.7.0":
   version "7.18.13"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.18.13.tgz#30aeb9e514f4100f7c1cb6e5ba472b30e48f519a"
   integrity sha512-ePqfTihzW0W6XAU+aMw2ykilisStJfDnsejDCXRchCcMJ4O0+8DhPXf2YUbZ6wjBlsEmZwLK/sPweWtu8hcJYQ==
+  dependencies:
+    "@babel/helper-string-parser" "^7.18.10"
+    "@babel/helper-validator-identifier" "^7.18.6"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.19.0":
+  version "7.19.0"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.19.0.tgz#75f21d73d73dc0351f3368d28db73465f4814600"
+  integrity sha512-YuGopBq3ke25BVSiS6fgF49Ul9gH1x70Bcr6bqRLjWCkcX8Hre1/5+z+IiWOIerRMSSEfGZVB9z9kyq7wVs9YA==
   dependencies:
     "@babel/helper-string-parser" "^7.18.10"
     "@babel/helper-validator-identifier" "^7.18.6"
@@ -1545,7 +1651,7 @@
   resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.8.0.tgz#f580f9beb67176fa57aae70b08ed510e1b18980f"
   integrity sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA==
 
-"@emotion/react@^11.10.0":
+"@emotion/react@^11.10.4":
   version "11.10.4"
   resolved "https://registry.yarnpkg.com/@emotion/react/-/react-11.10.4.tgz#9dc6bccbda5d70ff68fdb204746c0e8b13a79199"
   integrity sha512-j0AkMpr6BL8gldJZ6XQsQ8DnS9TxEQu1R+OGmDZiWjBAJtCcbt0tS3I/YffoqHXxH6MjgI7KdMbYKw3MEiU9eA==
@@ -2813,20 +2919,6 @@
     call-me-maybe "^1.0.1"
     glob-to-regexp "^0.3.0"
 
-"@mui/base@5.0.0-alpha.95":
-  version "5.0.0-alpha.95"
-  resolved "https://registry.yarnpkg.com/@mui/base/-/base-5.0.0-alpha.95.tgz#eac88ddb6ded633a73cd3c19638241f0f9fa274f"
-  integrity sha512-fcxnDeO7rBwzP0buVdI5fn0aA7NQ/AeUV5RzIIH0kOXVVT21HB4JFf41Qhwd0PIq63PXxmc6Fs2mdlzMYuPo9g==
-  dependencies:
-    "@babel/runtime" "^7.18.9"
-    "@emotion/is-prop-valid" "^1.2.0"
-    "@mui/types" "^7.2.0"
-    "@mui/utils" "^5.10.3"
-    "@popperjs/core" "^2.11.6"
-    clsx "^1.2.1"
-    prop-types "^15.8.1"
-    react-is "^18.2.0"
-
 "@mui/base@5.0.0-alpha.96":
   version "5.0.0-alpha.96"
   resolved "https://registry.yarnpkg.com/@mui/base/-/base-5.0.0-alpha.96.tgz#2189dd1012d0969ace69c3479b0aec2dbe9bbdc1"
@@ -2841,7 +2933,7 @@
     prop-types "^15.8.1"
     react-is "^18.2.0"
 
-"@mui/core-downloads-tracker@^5.10.3", "@mui/core-downloads-tracker@^5.10.4":
+"@mui/core-downloads-tracker@^5.10.4":
   version "5.10.4"
   resolved "https://registry.yarnpkg.com/@mui/core-downloads-tracker/-/core-downloads-tracker-5.10.4.tgz#6b208687f016e8f583ee14582b8a949d89b2f121"
   integrity sha512-VGekVa9dleJ+ii47+gXvKUV5a11T0nsjXN8bk5NqiJRQWRCAhbTHgsfZuctNcMeLW9FSf2gu6U0k2U6rhABKcA==
@@ -2853,7 +2945,7 @@
   dependencies:
     "@babel/runtime" "^7.18.9"
 
-"@mui/joy@^5.0.0-alpha.40":
+"@mui/joy@^5.0.0-alpha.44":
   version "5.0.0-alpha.44"
   resolved "https://registry.yarnpkg.com/@mui/joy/-/joy-5.0.0-alpha.44.tgz#c706d0130ebb61b86df2c21ecd1aa40d2903386b"
   integrity sha512-gmXBZSDwtesIPPcYKmb81oiJAXns0Hb7KVzUjpsVl0TDNvw+FEFIDFTqPxUV6jm9rA0Ln9PoYBpgm0tszliowA==
@@ -2869,15 +2961,15 @@
     prop-types "^15.8.1"
     react-is "^18.2.0"
 
-"@mui/material@^5.10.0":
-  version "5.10.3"
-  resolved "https://registry.yarnpkg.com/@mui/material/-/material-5.10.3.tgz#5497128ea7c8de1d40ba9bd95437d46d441fa1d1"
-  integrity sha512-g0lzHcqWHYeOEAxTzcwpM1I7b+wyiRTeXkEdRsspnOpZtb0H/1xg386tMFRGbxBJ4zfVGT+TWublofw7pyQkqw==
+"@mui/material@^5.10.4":
+  version "5.10.4"
+  resolved "https://registry.yarnpkg.com/@mui/material/-/material-5.10.4.tgz#a3a72f438614fe4319a6ee805542bb599fd6ec02"
+  integrity sha512-uwupjunU3p8XxZU4f2zF1GYlwB9GDxW1H05BMDPSh0u+37yLxuQDMMxwQQPUo9jSA5Y22/eR4Y71ScxKU89QHg==
   dependencies:
     "@babel/runtime" "^7.18.9"
-    "@mui/base" "5.0.0-alpha.95"
-    "@mui/core-downloads-tracker" "^5.10.3"
-    "@mui/system" "^5.10.3"
+    "@mui/base" "5.0.0-alpha.96"
+    "@mui/core-downloads-tracker" "^5.10.4"
+    "@mui/system" "^5.10.4"
     "@mui/types" "^7.2.0"
     "@mui/utils" "^5.10.3"
     "@types/react-transition-group" "^4.4.5"
@@ -2906,7 +2998,7 @@
     csstype "^3.1.0"
     prop-types "^15.8.1"
 
-"@mui/system@^5.10.3", "@mui/system@^5.10.4":
+"@mui/system@^5.10.4":
   version "5.10.4"
   resolved "https://registry.yarnpkg.com/@mui/system/-/system-5.10.4.tgz#4621cbae1bfc551c95e368d32850160b64034a67"
   integrity sha512-fE7LtYStPHPfq7EJXEVLQGvz23pS5YwSI7A4mWEFyyW21hHUh0c1opZXb7caHJsUTiBoC22W7R8GGfbVdSOnZA==
@@ -2936,10 +3028,10 @@
     prop-types "^15.8.1"
     react-is "^18.2.0"
 
-"@mui/x-data-grid@^5.15.2":
-  version "5.16.0"
-  resolved "https://registry.yarnpkg.com/@mui/x-data-grid/-/x-data-grid-5.16.0.tgz#4620efe1707f36153ede0c5aacb652a75cf9ab1f"
-  integrity sha512-pP1dsNAOWJQoxU/pTHKF/7uDVNASeTA2Ki8fdm6+TVLu8C4ISsg88vGPj8W3ikbdQ1geExzxO1LLX1atQGKTiA==
+"@mui/x-data-grid@^5.17.1":
+  version "5.17.1"
+  resolved "https://registry.yarnpkg.com/@mui/x-data-grid/-/x-data-grid-5.17.1.tgz#fbe72eae6a40f6401a6a2a0f9ded36447995cf47"
+  integrity sha512-EmXvQjc+DHuok7lsDBRzVJBaM8eXGULowhIPcUXCTvd6QReskRT+zh8cAzpSoqAohJwPUhrcMueeEwvoKs2s7A==
   dependencies:
     "@babel/runtime" "^7.18.9"
     "@mui/utils" "^5.9.3"
@@ -3284,6 +3376,11 @@
     "@octokit/types" "^7.0.0"
     universal-user-agent "^6.0.0"
 
+"@octokit/openapi-types@^13.1.0":
+  version "13.1.0"
+  resolved "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-13.1.0.tgz"
+  integrity sha512-Z7vzLqfTkoVQyoy/2iQla1N2I4Vav2wi4JbZK8QxIYAfBimhuflosFxmsqw5LTH7DkdNW46ZYpAcqJf0XaS8SQ==
+
 "@octokit/openapi-types@^13.6.0":
   version "13.6.0"
   resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-13.6.0.tgz#381884008e23fd82fd444553f6b4dcd24a5c4a4d"
@@ -3345,7 +3442,14 @@
     "@octokit/plugin-request-log" "^1.0.4"
     "@octokit/plugin-rest-endpoint-methods" "^6.0.0"
 
-"@octokit/types@^7.0.0", "@octokit/types@^7.2.0":
+"@octokit/types@^7.0.0":
+  version "7.1.0"
+  resolved "https://registry.npmjs.org/@octokit/types/-/types-7.1.0.tgz"
+  integrity sha512-+ClA0jRc9zGFj5mfQeQNfgTlelzhpAexbAueQG1t2Xn8yhgnsjkF8bgLcUUpwrpqkv296uXyiGwkqXRSU7KYzQ==
+  dependencies:
+    "@octokit/openapi-types" "^13.1.0"
+
+"@octokit/types@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@octokit/types/-/types-7.2.0.tgz#7ee0fc27f9f463d7ccf12ca5956988d498b3c6c4"
   integrity sha512-pYQ/a1U6mHptwhGyp6SvsiM4bWP2s3V95olUeTxas85D/2kN78yN5C8cGN+P4LwJSWUqIEyvq0Qn2WUn6NQRjw==
@@ -4481,7 +4585,7 @@
   resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-4.2.3.tgz#52d75430c9662cc85c160761c1421de483c7791f"
   integrity sha512-zdt5lYWs1dZaA3IxJbCgtAfHZJScRZONpiLL7YkeOkrme5MfjQqTpjq7LYbzpyuwPOh2Jx68le0PLl57JFv5hQ==
 
-"@tanstack/react-query@^4.0.5", "@tanstack/react-query@^4.1.3":
+"@tanstack/react-query@^4.0.5", "@tanstack/react-query@^4.2.3":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-4.2.3.tgz#782fd0f84553ba6219f1137a12ea28ab8cd3a3f3"
   integrity sha512-JLaMOxoJTkiAu7QpevRCt2uI/0vd3E8K/rSlCuRgWlcW5DeJDFpDS5kfzmLO5MOcD97fgsJRrDbxDORxR1FdJA==
@@ -4519,7 +4623,7 @@
     lodash "^4.17.15"
     redent "^3.0.0"
 
-"@testing-library/react@^13.3.0":
+"@testing-library/react@^13.4.0":
   version "13.4.0"
   resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-13.4.0.tgz#6a31e3bf5951615593ad984e96b9e5e2d9380966"
   integrity sha512-sXOGON+WNTh3MLE9rve97ftaZukN3oNf2KjDy7YTx6hcTO2uuLHuCGynMDhFwGw/jYf4OJ2Qk0i4i79qMNNkyw==
@@ -4750,7 +4854,7 @@
     "@types/node" "*"
     form-data "^3.0.0"
 
-"@types/node@*", "@types/node@^18.0.4", "@types/node@^18.7.14":
+"@types/node@*", "@types/node@^18.0.4":
   version "18.7.14"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.7.14.tgz#0fe081752a3333392d00586d815485a17c2cf3c9"
   integrity sha512-6bbDaETVi8oyIARulOE9qF1/Qdi/23z6emrUh0fNJRUmjznqrixD4MpGDdgOFk5Xb0m2H6Xu42JGdvAxaJR/wA==
@@ -4764,6 +4868,11 @@
   version "16.11.45"
   resolved "https://registry.npmjs.org/@types/node/-/node-16.11.45.tgz"
   integrity sha512-3rKg/L5x0rofKuuUt5zlXzOnKyIHXmIu5R8A0TuNDMF2062/AOIDBciFIjToLEJ/9F9DzkHNot+BpNsMI1OLdQ==
+
+"@types/node@^18.7.15":
+  version "18.7.15"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.7.15.tgz#20ae1ec80c57ee844b469f968a1cd511d4088b29"
+  integrity sha512-XnjpaI8Bgc3eBag2Aw4t2Uj/49lLBSStHWfqKvIuXD7FIrZyMLWp8KuAFHAqxMZYTF9l08N1ctUn9YNybZJVmQ==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
@@ -5043,7 +5152,7 @@
     "@typescript-eslint/typescript-estree" "5.36.1"
     debug "^4.3.4"
 
-"@typescript-eslint/parser@^5.36.1":
+"@typescript-eslint/parser@^5.36.2":
   version "5.36.2"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.36.2.tgz#3ddf323d3ac85a25295a55fcb9c7a49ab4680ddd"
   integrity sha512-qS/Kb0yzy8sR0idFspI9Z6+t7mqk/oRjnAYfewG+VN73opAUvmYL3oPIMmgOX6CnQS6gmVIXGshlb5RY/R22pA==
@@ -6074,6 +6183,14 @@ at-least-node@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
   integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
+
+atlassian-openapi@^1.0.8:
+  version "1.0.17"
+  resolved "https://registry.yarnpkg.com/atlassian-openapi/-/atlassian-openapi-1.0.17.tgz#968ade998b65f50fc0ff9f0780707301344a351b"
+  integrity sha512-8aW0Xgl9mVdL9dCABSZAvCayMPyh6uVu86UzOat8Kc1qDMUtXn2OxcwDsJfm/qCtBSeZ+GE/PkFxx3ZRIp3hFg==
+  dependencies:
+    jsonpointer "^5.0.0"
+    urijs "^1.19.10"
 
 atob@^2.1.2:
   version "2.1.2"
@@ -7301,6 +7418,11 @@ commander@^4.1.1:
   version "4.1.1"
   resolved "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz"
   integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
+
+commander@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-5.1.0.tgz#46abbd1652f8e059bddaef99bbdcb2ad9cf179ae"
+  integrity sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==
 
 commander@^6.2.1:
   version "6.2.1"
@@ -9006,7 +9128,7 @@ eslint@^6.1.0:
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
 
-eslint@^8.20.0, eslint@^8.22.0:
+eslint@^8.20.0, eslint@^8.23.0:
   version "8.23.0"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.23.0.tgz#a184918d288820179c6041bb3ddcc99ce6eea040"
   integrity sha512-pBG/XOn0MsJcKcTRLr27S5HpzQo4kLr+HjLQIyK4EiCsijDl/TB+h5uEuJU6bQ8Edvwz1XWOjpaP2qgnXGpTcA==
@@ -11427,6 +11549,14 @@ isomorphic-fetch@^2.1.1:
     node-fetch "^1.0.1"
     whatwg-fetch ">=0.10.0"
 
+isomorphic-fetch@^3:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz#0267b005049046d2421207215d45d6a262b8b8b4"
+  integrity sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==
+  dependencies:
+    node-fetch "^2.6.1"
+    whatwg-fetch "^3.4.1"
+
 isomorphic-unfetch@^3.1.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/isomorphic-unfetch/-/isomorphic-unfetch-3.1.0.tgz"
@@ -12085,7 +12215,7 @@ js-yaml@4.1.0, js-yaml@^4.1.0:
   dependencies:
     argparse "^2.0.1"
 
-js-yaml@^3.13.1:
+js-yaml@^3.13.1, js-yaml@^3.14.0:
   version "3.14.1"
   resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz"
   integrity sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==
@@ -12222,6 +12352,11 @@ jsonparse@^1.2.0, jsonparse@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
   integrity sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==
+
+jsonpointer@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/jsonpointer/-/jsonpointer-5.0.1.tgz#2110e0af0900fd37467b5907ecd13a7884a1b559"
+  integrity sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==
 
 jsprim@^1.2.2:
   version "1.4.2"
@@ -13838,6 +13973,27 @@ open@^8.4.0:
     define-lazy-prop "^2.0.0"
     is-docker "^2.1.1"
     is-wsl "^2.2.0"
+
+openapi-merge-cli@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/openapi-merge-cli/-/openapi-merge-cli-1.3.1.tgz#396e6b082d93890c69670cf05dcdefe90e9115d9"
+  integrity sha512-YGBkzuYrDc4kTMVoGrNTCI/eNCKtE5JcCGmcmkhtl0M7+hNXm4kP+n83ilZ+kCxa7/xicTj0cww/q1P4KxlQ8Q==
+  dependencies:
+    ajv "^6.12.2"
+    commander "^5.1.0"
+    es6-promise "^4.2.8"
+    isomorphic-fetch "^3"
+    js-yaml "^3.14.0"
+    openapi-merge "^1.2.0"
+
+openapi-merge@^1.2.0:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/openapi-merge/-/openapi-merge-1.3.2.tgz#dc77a8e85ac63a5d7373eb63f05ab8b93ff78380"
+  integrity sha512-qRWBwPMiKIUrAcKW6lstMPKpFEWy32dBbP1UjHH9jlWgw++2BCqOVbsjO5Wa4H1Ll3c4cn+lyi4TinUy8iswzw==
+  dependencies:
+    atlassian-openapi "^1.0.8"
+    lodash "^4.17.15"
+    ts-is-present "^1.1.1"
 
 optionator@^0.8.1, optionator@^0.8.3:
   version "0.8.3"
@@ -17140,6 +17296,11 @@ ts-dedent@^2.0.0:
   resolved "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz"
   integrity sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==
 
+ts-is-present@^1.1.1:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/ts-is-present/-/ts-is-present-1.2.2.tgz#ba59b4a9d2bc22b99d1ba7f4af3d5eb320408d95"
+  integrity sha512-cA5MPLWGWYXvnlJb4TamUUx858HVHBsxxdy8l7jxODOLDyGYnQOllob2A2jyDghGa5iJHs2gzFNHvwGJ0ZfR8g==
+
 ts-jest@^25.3.1:
   version "25.5.1"
   resolved "https://registry.npmjs.org/ts-jest/-/ts-jest-25.5.1.tgz"
@@ -17380,10 +17541,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-typedoc-plugin-markdown@^3.13.4:
-  version "3.13.5"
-  resolved "https://registry.yarnpkg.com/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.13.5.tgz#afe30978169b375b114b04357a2c8001db9608fb"
-  integrity sha512-E6bSn96MtiWTU4fr9wddD7d2T91XTtONj4Jdx2TZsjdAg/ig4ft2ECet/rNbBOiyw9MC0VO9toC/yvI8ZcY2PQ==
+typedoc-plugin-markdown@^3.13.6:
+  version "3.13.6"
+  resolved "https://registry.yarnpkg.com/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.13.6.tgz#a419794e3bdbe459fb22772d8e6e02bac05211c1"
+  integrity sha512-ISSc9v3BK7HkokxSBuJPttXox4tJ6hP0N9wfSIk0fmLN67+eqtAxbk97gs2nDiuha+RTO5eW9gdeAb+RPP0mgg==
   dependencies:
     handlebars "^4.7.7"
 
@@ -17397,7 +17558,7 @@ typedoc@^0.23.14:
     minimatch "^5.1.0"
     shiki "^0.11.1"
 
-"typescript@^3 || ^4", typescript@^4.6.4, typescript@^4.7.2, typescript@^4.7.4, typescript@^4.8.2:
+"typescript@^3 || ^4", typescript@^4.6.4, typescript@^4.7.2, typescript@^4.8.2:
   version "4.8.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.2.tgz#e3b33d5ccfb5914e4eeab6699cf208adee3fd790"
   integrity sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==
@@ -17640,6 +17801,11 @@ uri-js@^4.2.2:
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
+
+urijs@^1.19.10:
+  version "1.19.11"
+  resolved "https://registry.yarnpkg.com/urijs/-/urijs-1.19.11.tgz#204b0d6b605ae80bea54bea39280cdb7c9f923cc"
+  integrity sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ==
 
 urix@^0.1.0:
   version "0.1.0"
@@ -18076,7 +18242,7 @@ whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.5:
   dependencies:
     iconv-lite "0.4.24"
 
-whatwg-fetch@>=0.10.0:
+whatwg-fetch@>=0.10.0, whatwg-fetch@^3.4.1:
   version "3.6.2"
   resolved "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz"
   integrity sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==


### PR DESCRIPTION
I manually built this `workspace.yaml` as a prototype of what the server might produce.

From the `/lib/nile` directory, you can run:
```
yarn openapi-merge-cli --config ./spec/openapi-merge.yaml

yarn openapi-generator-cli generate -t templates -i spec/merged.yaml -g typescript-fetch --package-name nile -o src/generated/experimental --additional-properties=ngVersion=6.1.7,npmName=theniledev,supportsES6=true,npmVersion=6.9.0,withInterfaces=true,withSeparateModelsAndApi=true,moduleName=Nile,typescriptThreePlus=true,projectName=@theniledev/js
```
to produce the generated client in `src/generated/experimental`. 

The most interesting thing I've noticed so far is that it generates an `EventsApi` that has listeners specific to the entity types, which will make them way easier to work with. 

If this all seems reasonable I'll work backwards from here to generate the workspace yaml server-side.