### PR TITLE
feat(react): add  function for forms

### DIFF
--- a/packages/react/src/components/EntityForm/EntityForm.tsx
+++ b/packages/react/src/components/EntityForm/EntityForm.tsx
@@ -8,6 +8,7 @@ import SimpleForm, { Attribute, AttributeType } from '../../lib/SimpleForm';
 type AllowedAny = any;
 
 type Props = {
+  beforeMutate?: (data: AllowedAny) => AllowedAny;
   onSuccess: (data: AllowedAny) => void;
   onError?: (error: Error) => void;
   cancelLink?: string;
@@ -60,7 +61,20 @@ export const processFormData = (data: AllowedAny, fields: Attribute[]) => {
 
 export default function EntityForm(props: Props) {
   const nile = useNile();
-  const { fields, org, entityType, cancelLink, onSuccess, onError } = props;
+  const {
+    fields,
+    org,
+    entityType,
+    cancelLink,
+    onSuccess,
+    onError,
+    beforeMutate,
+  } = props;
+
+  const handleMutate =
+    typeof beforeMutate === 'function'
+      ? beforeMutate
+      : (data: AllowedAny): AllowedAny => data;
 
   const mutation = useMutation(
     (data: AllowedAny) => {
@@ -68,7 +82,7 @@ export default function EntityForm(props: Props) {
       return nile.entities.createInstance({
         org,
         type: entityType,
-        body,
+        body: handleMutate(body),
       });
     },
     {

--- a/packages/react/src/components/LoginForm/index.tsx
+++ b/packages/react/src/components/LoginForm/index.tsx
@@ -1,21 +1,27 @@
 import React from 'react';
 import { useMutation } from '@tanstack/react-query';
+import { LoginInfo } from '@theniledev/js';
 
 import { Attribute } from '../../lib/SimpleForm/types';
 import { useNile } from '../../context';
 import SimpleForm, { AttributeType } from '../../lib/SimpleForm';
 
-import { Props } from './types';
+import { Props, AllowedAny } from './types';
 
 export default function LoginForm(props: Props) {
   const nile = useNile();
 
-  const { attributes, onSuccess, onError } = props;
+  const { attributes, onSuccess, onError, beforeMutate } = props;
+
+  const handleMutate =
+    typeof beforeMutate === 'function'
+      ? beforeMutate
+      : (data: AllowedAny): AllowedAny => data;
 
   const mutation = useMutation(
     (data: { email: string; password: string }) => {
-      const { email, password } = data;
-      return nile.users.loginUser({ loginInfo: { email, password } });
+      const _data = handleMutate(data);
+      return nile.users.loginUser({ loginInfo: _data as LoginInfo });
     },
     {
       onSuccess: (token, data) => {

--- a/packages/react/src/components/LoginForm/types.ts
+++ b/packages/react/src/components/LoginForm/types.ts
@@ -2,7 +2,11 @@ import { Attribute } from '../../lib/SimpleForm/types';
 
 type LoginSuccess = (LoginInfo: { email: string; password: string }) => void;
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type AllowedAny = any;
+
 export interface Props {
+  beforeMutate?: (data: AllowedAny) => AllowedAny;
   onSuccess: LoginSuccess;
   onError?: (error: Error) => void;
   attributes?: Attribute[];

--- a/packages/react/src/components/OrganizationForm/index.tsx
+++ b/packages/react/src/components/OrganizationForm/index.tsx
@@ -5,7 +5,7 @@ import { useNile } from '../../context';
 import { useMutation } from '../../lib/queries';
 import SimpleForm, { AttributeType } from '../../lib/SimpleForm';
 
-import { Props } from './types';
+import { AllowedAny, Props } from './types';
 
 const attributes = [
   {
@@ -18,13 +18,17 @@ const attributes = [
 ];
 
 export default function AddOrgForm(props: Props) {
-  const { onSuccess, onError, cancelLink } = props;
+  const { onSuccess, onError, cancelLink, beforeMutate } = props;
   const nile = useNile();
+  const handleMutate =
+    typeof beforeMutate === 'function'
+      ? beforeMutate
+      : (data: AllowedAny): AllowedAny => data;
 
   const mutation = useMutation(
     (data: CreateOrganizationRequest) =>
       nile.organizations.createOrganization({
-        createOrganizationRequest: data,
+        createOrganizationRequest: handleMutate(data),
       }),
     {
       onSuccess: (data: Organization) => {

--- a/packages/react/src/components/OrganizationForm/types.ts
+++ b/packages/react/src/components/OrganizationForm/types.ts
@@ -2,7 +2,11 @@ import { Organization } from '@theniledev/js';
 
 type OrgCreateSuccess = (org: Organization) => void;
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type AllowedAny = any;
+
 export interface Props {
+  beforeMutate?: (data: AllowedAny) => AllowedAny;
   onSuccess: OrgCreateSuccess;
   onError?: (error: Error) => void;
   cancelLink?: string;


### PR DESCRIPTION
adds the ability to change form values when desired prior to submission.

The original intent of this is to support a "hidden" or default field value you know a user will not provide. eg create a new `SaaSDB` and set a value to `Provisioning`. A stop gap until `default` is supported on the BE, but I can also see how this could be useful in a very custom scenario.