### PR TITLE
fix(server): type things better

### DIFF
--- a/lib/nile/spec/api2.yaml
+++ b/lib/nile/spec/api2.yaml
@@ -4,7 +4,7 @@ info:
   description: Making SaaS chill.
   contact:
     email: support@thenile.dev
-  version: 0.1.0-01c2fab
+  version: 0.1.0-48d6417
 servers:
   - url: localhost:8080
 paths:
@@ -618,7 +618,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CreateUserResponse'
+                $ref: '#/components/schemas/LoginUserResponse'
       security:
         - jwtBearerAuth: []
   /workspaces/{workspaceSlug}/databases/{databaseName}/tenants/{tenantId}/users/{userId}:
@@ -703,9 +703,9 @@ paths:
         '200':
           description: User logged in successfully
           content:
-            text/plain:
+            application/json:
               schema:
-                type: string
+                $ref: '#/components/schemas/LoginUserResponse'
         '401':
           description: User authentication failed
           content:
@@ -741,7 +741,51 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CreateUserResponse'
+                $ref: '#/components/schemas/LoginUserResponse'
+  /workspaces/{workspaceSlug}/databases/{databaseName}/users/{userId}:
+    get:
+      tags:
+        - users
+      summary: Get a user
+      description: Get a user by id
+      operationId: getUser
+      parameters:
+        - name: workspaceSlug
+          in: path
+          required: false
+          schema:
+            type: string
+        - name: databaseName
+          in: path
+          required: false
+          schema:
+            type: string
+        - name: userId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: User found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+        '404':
+          description: User not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+      security:
+        - jwtBearerAuth: []
   /workspaces/{workspaceSlug}/databases/{databaseName}/users/oidc/callback:
     get:
       tags:
@@ -803,9 +847,9 @@ paths:
         '200':
           description: User logged in successfully
           content:
-            text/plain:
+            application/json:
               schema:
-                type: string
+                $ref: '#/components/schemas/LoginUserResponse'
         '401':
           description: User authentication failed
           content:
@@ -1073,7 +1117,7 @@ components:
           type: string
         name:
           type: string
-    CreateUserResponse:
+    LoginUserResponse:
       required:
         - id
         - token
@@ -1085,11 +1129,11 @@ components:
           $ref: '#/components/schemas/Token'
     Token:
       required:
-        - token
+        - jwt
         - type
       type: object
       properties:
-        token:
+        jwt:
           type: string
         maxAge:
           minimum: 0
@@ -1123,11 +1167,8 @@ components:
           type: array
           items:
             type: string
-        emails:
-          uniqueItems: true
-          type: array
-          items:
-            type: string
+        email:
+          type: string
         preferredName:
           type: string
     CreateWorkspaceRequest:

--- a/lib/nile/src/index.ts
+++ b/lib/nile/src/index.ts
@@ -13,3 +13,6 @@ export * from './EventsApi';
 
 export { default as RestAPI } from './RestApi';
 export { DatabaseRestAPI } from './RestApi';
+
+export * as RestModels from './client2/src/models';
+export * as RestAPIs from './client2/src/apis';

--- a/lib/nile/test/RestAPI.test.ts
+++ b/lib/nile/test/RestAPI.test.ts
@@ -17,6 +17,7 @@ describe('nile db', () => {
           'createTenantUser',
           'createUser',
           'getTenantUser',
+          'getUser',
           'handleOIDCCallback',
           'listTenantUsers',
           'loginOIDCUser',

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -58,6 +58,7 @@
     "typescript": "^4.9.4"
   },
   "dependencies": {
+    "@theniledev/js": "^1.0.0-alpha.180",
     "base-x": "^4.0.0",
     "knex": "^2.4.2",
     "pg": "^8.10.0"

--- a/packages/server/src/auth/index.ts
+++ b/packages/server/src/auth/index.ts
@@ -1,5 +1,7 @@
+import { RestModels } from '@theniledev/js';
+
 import { Config } from '../utils/Config';
-import Requester from '../utils/Requester';
+import Requester, { NileRequest, NileResponse } from '../utils/Requester';
 import { ResponseError } from '../utils/ResponseError';
 
 export default class Auth extends Config {
@@ -12,10 +14,14 @@ export default class Auth extends Config {
     )}/databases/${encodeURIComponent(this.database)}/users/login`;
   }
 
-  login = async (req: Request, init?: RequestInit): Promise<Response> => {
-    const headers = new Headers(req.headers);
+  login = async (
+    req: NileRequest<RestModels.CreateBasicUserRequest>,
+    init?: RequestInit
+  ): NileResponse<RestModels.LoginUserResponse> => {
+    const headers =
+      req instanceof Request ? new Headers(req.headers) : new Headers();
     const _requester = new Requester(this);
-    const res = await _requester.post(req, this.loginUrl, init);
+    const res = await _requester.post(req as Request, this.loginUrl, init);
     if (res instanceof ResponseError) {
       return res.response;
     }
@@ -36,7 +42,10 @@ export default class Auth extends Config {
     )}/databases/${encodeURIComponent(this.database)}/users`;
   }
 
-  signUp = async (req: Request, init?: RequestInit): Promise<Response> => {
+  signUp = async (
+    req: NileRequest<RestModels.CreateBasicUserRequest>,
+    init?: RequestInit
+  ): NileResponse<RestModels.LoginUserResponse> => {
     const _requester = new Requester(this);
     return _requester.post(req, this.signUpUrl, init);
   };

--- a/packages/server/src/auth/login/login.test.ts
+++ b/packages/server/src/auth/login/login.test.ts
@@ -1,5 +1,5 @@
 import { Config } from '../../utils/Config';
-import { FakeResponse, _fetch } from '../../../test/fetch.mock';
+import { FakeRequest, FakeResponse, _fetch } from '../../../test/fetch.mock';
 import Auth from '../';
 
 jest.mock('../../utils/ResponseError', () => ({
@@ -10,14 +10,14 @@ describe('login', () => {
   it('sets a cookie at login', async () => {
     //@ts-expect-error - test
     global.Response = FakeResponse;
+    //@ts-expect-error - test
+    global.Request = FakeRequest;
     global.fetch = _fetch({ jwt: 'adfasdfdsa' });
     const { login } = new Auth(
       new Config({ workspace: 'workspace', database: 'database' })
     );
-    const params = {
-      body: { email: 'email', password: 'password' },
-    } as unknown as Request;
-    const resp = (await login(params)) as unknown as FakeResponse;
+    const params = { email: 'email', password: 'password' };
+    const resp = await login(params);
     const headers = new Headers(resp.headers);
     const cookie = headers.get('set-cookie');
     expect(cookie).toEqual('token=adfasdfdsa; path=/; samesite=lax; httponly;');

--- a/packages/server/src/auth/signUp/signUp.test.ts
+++ b/packages/server/src/auth/signUp/signUp.test.ts
@@ -1,5 +1,5 @@
 import { Config } from '../../utils/Config';
-import { FakeResponse, _fetch } from '../../../test/fetch.mock';
+import { FakeRequest, FakeResponse, _fetch } from '../../../test/fetch.mock';
 import Auth from '../';
 
 jest.mock('../../utils/ResponseError', () => ({
@@ -10,15 +10,14 @@ describe('signUp', () => {
   it('does a post', async () => {
     //@ts-expect-error - test
     global.Response = FakeResponse;
+    //@ts-expect-error - test
+    global.Request = FakeRequest;
     global.fetch = _fetch();
     const { signUp } = new Auth(
       new Config({ workspace: 'workspace', database: 'database' })
     );
 
-    const params = {
-      body: { email: 'email', password: 'password' },
-    } as unknown as Request;
-    const res = await signUp(params);
+    const res = await signUp({ email: 'email', password: 'password' });
     //@ts-expect-error - test
     expect(res.config).toEqual(
       'https://prod.thenile.dev/workspaces/workspace/databases/database/users'

--- a/packages/server/src/users/createTenantUser/createTenantUser.test.ts
+++ b/packages/server/src/users/createTenantUser/createTenantUser.test.ts
@@ -20,12 +20,8 @@ describe('createUser', () => {
     global.fetch = _fetch();
     const { createTenantUser } = new Users(new Config(config));
 
-    const headers = new Headers();
-    headers.set('referer', 'http://localhost:8080?tenantId=tenant');
-    const params = {
-      body: { email: 'email', password: 'password' },
-      headers,
-    } as unknown as Request;
+    const params = { email: 'email', password: 'password' };
+
     const res = await createTenantUser(params);
     //@ts-expect-error - test
     expect(res.config).toEqual(

--- a/packages/server/src/users/index.ts
+++ b/packages/server/src/users/index.ts
@@ -1,10 +1,12 @@
+import { RestModels } from '@theniledev/js';
+
 import { Config } from '../utils/Config';
-import Requester from '../utils/Requester';
+import Requester, { NileRequest, NileResponse } from '../utils/Requester';
 import { ResponseError } from '../utils/ResponseError';
 import { handleTenantId } from '../utils/fetch';
 import { UUID, decode, encode } from '../utils/uuid';
 
-export default class Auth extends Config {
+export default class Users extends Config {
   uuid: UUID;
   constructor(config: Config) {
     super(config);
@@ -22,19 +24,11 @@ export default class Auth extends Config {
   }
 
   createTenantUser = async (
-    req: Request | { email: string; password: string },
+    req: NileRequest<RestModels.CreateBasicUserRequest & { tenantId?: string }>,
     init?: RequestInit
-  ): Promise<Response> => {
+  ): NileResponse<RestModels.LoginUserResponse> => {
     const _requester = new Requester(this);
-    if (!(req instanceof Request)) {
-      return _requester.rawRequest(
-        'POST',
-        this.createTenantUserUrl,
-        JSON.stringify(req),
-        init
-      );
-    }
-    const error = handleTenantId(new Headers(req.headers), this);
+    const error = await handleTenantId(req, this);
     if (error instanceof ResponseError) {
       return error.response;
     }

--- a/packages/server/src/utils/Requester/index.ts
+++ b/packages/server/src/utils/Requester/index.ts
@@ -1,9 +1,10 @@
-import { Config } from '../utils/Config';
+import { Config } from '../Config';
+import { ResponseError } from '../ResponseError';
+import { _fetch } from '../fetch';
 
-import { ResponseError } from './ResponseError';
-import { _fetch } from './fetch';
+export { NileResponse, NileRequest } from './types';
 
-export default class Requester extends Config {
+export default class Requester<T> extends Config {
   constructor(config: Config) {
     super(config);
   }
@@ -33,20 +34,17 @@ export default class Requester extends Config {
   protected async request(
     method: 'POST' | 'GET',
     url: string,
-    req: Request,
+    req: T,
     init?: RequestInit
   ): Promise<Response> {
-    const body = await new Response(req.body).text();
-    return this.rawRequest(method, url, body, init);
+    if (req instanceof Request) {
+      const body = await new Response(req.body).text();
+      return this.rawRequest(method, url, body, init);
+    }
+    return this.rawRequest('POST', url, JSON.stringify(req), init);
   }
 
-  post = async (
-    req: Request,
-    url: string,
-    init?: RequestInit
-  ): Promise<Response> => {
-    const resp = await this.request('POST', url, req, init);
-    const text = await resp.text();
-    return new Response(text, { status: resp.status, ...init });
+  post = async (req: T, url: string, init?: RequestInit): Promise<Response> => {
+    return await this.request('POST', url, req, init);
   };
 }

--- a/packages/server/src/utils/Requester/types.ts
+++ b/packages/server/src/utils/Requester/types.ts
@@ -1,0 +1,59 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { RestModels } from '@theniledev/js';
+
+// taken from ts lib dom
+interface NileBody<R, B> {
+  readonly body: ReadableStream<Uint8Array> | null | B;
+  readonly bodyUsed: boolean;
+  arrayBuffer(): Promise<ArrayBuffer>;
+  blob(): Promise<Blob>;
+  formData(): Promise<FormData>;
+  json(): Promise<R>;
+  text(): Promise<string>;
+}
+
+interface NResponse<T> extends NileBody<T, any> {
+  readonly headers: Headers;
+  readonly ok: boolean;
+  readonly redirected: boolean;
+  readonly status: number;
+  readonly statusText: string;
+  readonly type: ResponseType;
+  readonly url: string;
+  clone(): Response;
+}
+
+interface NRequest<T> extends NileBody<any, T> {
+  /** Returns the cache mode associated with request, which is a string indicating how the request will interact with the browser's cache when fetching. */
+  readonly cache: RequestCache;
+  /** Returns the credentials mode associated with request, which is a string indicating whether credentials will be sent with the request always, never, or only when sent to a same-origin URL. */
+  readonly credentials: RequestCredentials;
+  /** Returns the kind of resource requested by request, e.g., "document" or "script". */
+  readonly destination: RequestDestination;
+  /** Returns a Headers object consisting of the headers associated with request. Note that headers added in the network layer by the user agent will not be accounted for in this object, e.g., the "Host" header. */
+  readonly headers: Headers;
+  /** Returns request's subresource integrity metadata, which is a cryptographic hash of the resource being fetched. Its value consists of multiple hashes separated by whitespace. [SRI] */
+  readonly integrity: string;
+  /** Returns a boolean indicating whether or not request can outlive the global in which it was created. */
+  readonly keepalive: boolean;
+  /** Returns request's HTTP method, which is "GET" by default. */
+  readonly method: string;
+  /** Returns the mode associated with request, which is a string indicating whether the request will use CORS, or will be restricted to same-origin URLs. */
+  readonly mode: RequestMode;
+  /** Returns the redirect mode associated with request, which is a string indicating how redirects for the request will be handled during fetching. A request will follow redirects by default. */
+  readonly redirect: RequestRedirect;
+  /** Returns the referrer of request. Its value can be a same-origin URL if explicitly set in init, the empty string to indicate no referrer, and "about:client" when defaulting to the global's default. This is used during fetching to determine the value of the `Referer` header of the request being made. */
+  readonly referrer: string;
+  /** Returns the referrer policy associated with request. This is used during fetching to compute the value of the request's referrer. */
+  readonly referrerPolicy: ReferrerPolicy;
+  /** Returns the signal associated with request, which is an AbortSignal object indicating whether or not request has been aborted, and its abort event handler. */
+  readonly signal: AbortSignal;
+  /** Returns the URL of request as a string. */
+  readonly url: string;
+  clone(): Request;
+}
+
+export type NileRequest<T> = NRequest<T> | T;
+
+export type NileResponse<T> = Promise<NResponse<T & RestModels.APIError>>;

--- a/packages/server/src/utils/fetch.ts
+++ b/packages/server/src/utils/fetch.ts
@@ -1,24 +1,17 @@
 import { ResponseError } from './ResponseError';
 import { Config } from './Config';
+import { NileRequest } from './Requester';
 
 export function handleTenantId(
-  headers: Headers,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  req: NileRequest<any>,
   config: Config
 ): ResponseError | void {
   // already set, no need to try and figure it out
   if (config.tenantId) {
     return;
   }
-  const from = headers.get('referer');
-  if (from) {
-    const { searchParams } = new URL(from);
-    const tenantId = searchParams.get('tenantId');
-    if (tenantId) {
-      config.tenantId = tenantId;
-      return;
-    }
-  }
-  return new ResponseError(null, { status: 400 });
+  return new ResponseError('tenant id needs to be set', { status: 400 });
 }
 
 function getTokenFromCookie(headers: Headers, cookieKey: void | string) {

--- a/packages/server/test/fetch.mock.ts
+++ b/packages/server/test/fetch.mock.ts
@@ -27,7 +27,18 @@ export class FakeResponse {
   };
 }
 
-export class FakeRequest {}
+export class FakeRequest {
+  [key: string]: Something;
+  constructor(url: string, config?: RequestInit) {
+    this.payload = config?.body;
+  }
+  json = async () => {
+    return JSON.parse(this.payload);
+  };
+  text = async () => {
+    return this.payload;
+  };
+}
 
 export const _fetch = (payload?: Record<string, Something>) =>
   (async (config: Config, path: string, opts?: RequestInit) => {

--- a/packages/server/tsconfig.build.json
+++ b/packages/server/tsconfig.build.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig",
   "include": ["src/**/*"],
   "compilerOptions": {
-    "rootDir": "./src"
+    "baseUrl": "./src"
   },
   "exclude": ["**/*test.ts", "openapi"]
 }

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -8,8 +8,6 @@
     "declaration": true,
     // output .js.map sourcemap files for consumers
     "sourceMap": true,
-    // match output dir to input dir. e.g. dist/index instead of dist/src/index
-    "rootDir": "./",
     // stricter type-checking for stronger correctness. Recommended by TS
     "strict": true,
     // linter checks for common issues


### PR DESCRIPTION
@mpokryva things are now strongly typed. Also took the opportunity to support a JSON payload in addition to a Request object in all cases.

Adding functions should generally look like this:
```
signUp = async (
    req: NileRequest<RestModels.CreateBasicUserRequest>,
    init?: RequestInit
  ): Promise<NileResponse<RestModels.LoginUserResponse>> => {
    const _requester = new Requester(this);
    return _requester.post(req, this.signUpUrl, init);
  };

```

One sad part is that keeping the spec from the js client and server is a bit sad... along with the possible types. 

At some point in the future, will need to take the spec and split it for what the sdk supports vs what the raw API does, but that's a problem for later. We can just deal with ensuring tests do what we think they should and