### PR TITLE
fix(server): add better extensions

### DIFF
--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -34,6 +34,8 @@
     "@niledatabase/server": "*"
   },
   "devDependencies": {
+    "@types/express": "^5",
+    "express": "^5.1.0",
     "jest": "^29.7.0",
     "ts-jest": "^29.3.4",
     "tsup": "^8.5.0"

--- a/packages/server/src/Server.test.ts
+++ b/packages/server/src/Server.test.ts
@@ -99,7 +99,7 @@ describe('Server', () => {
   });
 
   it('should return configured paths', () => {
-    const paths = server.getPaths();
+    const { paths } = server;
     expect(typeof paths).toBe('object');
   });
 

--- a/packages/server/src/api/handlers/Get.test.ts
+++ b/packages/server/src/api/handlers/Get.test.ts
@@ -1,10 +1,10 @@
-import {
-  HEADER_ORIGIN,
-  HEADER_SECURE_COOKIES,
-  TENANT_COOKIE,
-} from '../../utils/constants';
+import { HEADER_ORIGIN, HEADER_SECURE_COOKIES } from '../../utils/constants';
 import { Config } from '../../utils/Config';
-import { appRoutes } from '../utils/routes';
+import {
+  appRoutes,
+  DefaultNileAuthRoutes,
+  NileAuthRoutes,
+} from '../utils/routes';
 
 import GETTER from './GET';
 
@@ -24,56 +24,46 @@ describe('getter', () => {
     (global.fetch as jest.Mock).mockClear();
   });
 
-  [
-    'me',
-    'users',
-    'users/${userId}',
-    'tenants',
-    'tenants/{tenantId}',
-    'auth/signin',
-    'tenants/${tenantId}/users/${userId}',
-    'tenants/{tenantId}/users',
-    'users/${userId}/tenants',
-  ].forEach((key) => {
-    it(`matches ${key} `, async () => {
-      const headersArray: { key: string; value: string }[] = [];
-      let params: Request = {} as Request;
+  [...Object.values(NileAuthRoutes), ...Object.values(DefaultNileAuthRoutes)]
+    .filter(
+      (str: string) =>
+        DefaultNileAuthRoutes.SIGNUP !== str &&
+        DefaultNileAuthRoutes.TENANT_USER !== str
+    )
+    .forEach((key) => {
+      it(`matches ${key} `, async () => {
+        const headersArray: { key: string; value: string }[] = [];
+        let params: Request = {} as Request;
 
-      const req = {
-        nextUrl: {
-          pathname: `/api/${key}`,
-        },
-        method: 'GET',
-        headers: new Headers({
-          [TENANT_COOKIE]: '123',
-          host: 'http://localhost:3000',
-        }),
-        url: `http://localhost:3001/api/${key}`,
-        clone: jest.fn(() => ({ body: '{}' })),
-      };
+        const init = {
+          method: 'GET',
+          headers: new Headers({
+            host: 'http://localhost:3000',
+          }),
+        };
+        const url = `http://localhost:3001/api${key}`;
 
-      (global.fetch as jest.Mock) = jest.fn((url, p) => {
-        if (p) {
-          params = new Request(url, p);
-        }
-        return Promise.resolve({ status: 200 });
+        (global.fetch as jest.Mock) = jest.fn((url, p) => {
+          if (p) {
+            params = new Request(url, p);
+          }
+          return Promise.resolve({ status: 200 });
+        });
+
+        const fn = await apiGet(new Request(url, init));
+
+        expect(fn).toBeTruthy();
+        expect((fn as Response)?.status).toEqual(200);
+        params.headers.forEach((value, key) => {
+          if (key !== 'content-type') {
+            headersArray.push({ key, value });
+          }
+        });
+        expect(headersArray).toEqual([
+          { key: 'host', value: 'localhost:3001' },
+          { key: HEADER_ORIGIN, value: 'http://localhost:3001' },
+          { key: HEADER_SECURE_COOKIES, value: 'false' },
+        ]);
       });
-
-      const fn = await apiGet(req as unknown as Request);
-
-      expect(fn).toBeTruthy();
-      expect(fn?.status).toEqual(200);
-      params.headers.forEach((value, key) => {
-        if (key !== 'content-type') {
-          headersArray.push({ key, value });
-        }
-      });
-      expect(headersArray).toEqual([
-        { key: 'host', value: 'localhost:3001' },
-        { key: HEADER_ORIGIN, value: 'http://localhost:3001' },
-        { key: HEADER_SECURE_COOKIES, value: 'false' },
-        { key: TENANT_COOKIE, value: '123' },
-      ]);
     });
-  });
 });

--- a/packages/server/src/api/handlers/POST.test.ts
+++ b/packages/server/src/api/handlers/POST.test.ts
@@ -1,10 +1,10 @@
-import { appRoutes } from '../utils/routes';
-import { Config } from '../../utils/Config';
 import {
-  HEADER_ORIGIN,
-  HEADER_SECURE_COOKIES,
-  TENANT_COOKIE,
-} from '../../utils/constants';
+  appRoutes,
+  DefaultNileAuthRoutes,
+  NileAuthRoutes,
+} from '../utils/routes';
+import { Config } from '../../utils/Config';
+import { HEADER_ORIGIN, HEADER_SECURE_COOKIES } from '../../utils/constants';
 
 import POSTER from './POST';
 
@@ -14,60 +14,49 @@ describe('poster', () => {
     appRoutes(),
     new Config({ apiUrl: 'http://thenile.dev/v2/databases/testdb' })
   );
-  global.fetch = jest.fn();
+  (global.fetch as jest.Mock) = jest.fn();
 
   beforeEach(() => {
-    //@ts-expect-error - fetch
-    global.fetch.mockClear();
+    (global.fetch as jest.Mock).mockClear();
   });
 
-  [
-    'auth/signin',
-    'tenants',
-    'tenants/{tenantId}',
-    'tenants/{tenantId}/users',
-    'tenants/${tenantId}/users/${userId}',
-    'users',
-    'users/${userId}',
-    'users/${userId}/tenants',
-  ].forEach((key) => {
-    it(`matches ${key} `, async () => {
-      const headersArray: { key: string; value: string }[] = [];
-      let params: Request = {} as Request;
+  [...Object.values(NileAuthRoutes), ...Object.values(DefaultNileAuthRoutes)]
+    .filter((str) => str !== DefaultNileAuthRoutes.ME)
+    .forEach((key) => {
+      it(`matches ${key} `, async () => {
+        const headersArray: { key: string; value: string }[] = [];
+        let params: Request = {} as Request;
 
-      const req = {
-        method: 'POST',
-        [TENANT_COOKIE]: '123',
-        nextUrl: {
-          pathname: `/api/${key}`,
-        },
-        headers: new Headers({ host: 'http://localhost:3000' }),
-        url: `http://localhost:3001/api/${key}`,
-        clone: jest.fn(() => ({ body: '{}' })),
-      };
+        const init = {
+          method: 'POST',
+          headers: new Headers({
+            host: 'http://localhost:3000',
+          }),
+        };
+        const url = `http://localhost:3001/api${key}`;
 
-      //@ts-expect-error - fetch
-      global.fetch = jest.fn((url, p) => {
-        if (p) {
-          params = new Request(url, p);
-        }
-        return Promise.resolve({ status: 200 });
+        //@ts-expect-error - fetch
+        global.fetch = jest.fn((url, p) => {
+          if (p) {
+            params = new Request(url, p);
+          }
+          return Promise.resolve({ status: 200 });
+        });
+
+        const fn = await apiGet(new Request(url, init));
+
+        expect(fn).toBeTruthy();
+        expect((fn as Response)?.status).toEqual(200);
+        params.headers.forEach((value, key) => {
+          if (key !== 'content-type') {
+            headersArray.push({ key, value });
+          }
+        });
+        expect(headersArray).toEqual([
+          { key: 'host', value: 'localhost:3001' },
+          { key: HEADER_ORIGIN, value: 'http://localhost:3001' },
+          { key: HEADER_SECURE_COOKIES, value: 'false' },
+        ]);
       });
-
-      const fn = await apiGet(req as unknown as Request);
-
-      expect(fn).toBeTruthy();
-      expect(fn?.status).toEqual(200);
-      params.headers.forEach((value, key) => {
-        if (key !== 'content-type') {
-          headersArray.push({ key, value });
-        }
-      });
-      expect(headersArray).toEqual([
-        { key: 'host', value: 'localhost:3001' },
-        { key: HEADER_ORIGIN, value: 'http://localhost:3001' },
-        { key: HEADER_SECURE_COOKIES, value: 'false' },
-      ]);
     });
-  });
 });

--- a/packages/server/src/api/handlers/PUT.test.ts
+++ b/packages/server/src/api/handlers/PUT.test.ts
@@ -1,10 +1,10 @@
-import { appRoutes } from '../utils/routes';
-import { Config } from '../../utils/Config';
 import {
-  HEADER_ORIGIN,
-  HEADER_SECURE_COOKIES,
-  TENANT_COOKIE,
-} from '../../utils/constants';
+  appRoutes,
+  DefaultNileAuthRoutes,
+  NileAuthRoutes,
+} from '../utils/routes';
+import { Config } from '../../utils/Config';
+import { HEADER_ORIGIN, HEADER_SECURE_COOKIES } from '../../utils/constants';
 
 import PUTTER from './PUT';
 
@@ -17,56 +17,54 @@ describe('Putter', () => {
   global.fetch = jest.fn();
 
   beforeEach(() => {
-    //@ts-expect-error - fetch
-    global.fetch.mockClear();
+    (global.fetch as jest.Mock).mockClear();
   });
 
   [
-    'tenants',
-    'tenants/{tenantId}',
-    'tenants/{tenantId}/users',
-    'tenants/${tenantId}/users/${userId}',
-    'users',
-    'users/${userId}',
-    'users/${userId}/tenants',
-  ].forEach((key) => {
-    it(`matches ${key} `, async () => {
-      const headersArray: { key: string; value: string }[] = [];
-      let params: Request = {} as Request;
+    ...Object.values(DefaultNileAuthRoutes),
+    NileAuthRoutes.PASSWORD_RESET,
+    `${DefaultNileAuthRoutes.TENANT_USER}/link`,
+  ]
+    .filter(
+      (str) =>
+        str !== DefaultNileAuthRoutes.SIGNUP &&
+        str !== DefaultNileAuthRoutes.TENANT_USERS &&
+        str !== DefaultNileAuthRoutes.TENANT_USER
+    )
+    .forEach((key) => {
+      it(`matches ${key} `, async () => {
+        const headersArray: { key: string; value: string }[] = [];
+        let params: Request = {} as Request;
 
-      const req = {
-        method: 'POST',
-        [TENANT_COOKIE]: '123',
-        nextUrl: {
-          pathname: `/api/${key}`,
-        },
-        headers: new Headers({ host: 'http://localhost:3000' }),
-        url: `http://localhost:3001/api/${key}`,
-        clone: jest.fn(() => ({ body: '{}' })),
-      };
+        const init = {
+          method: 'PUT',
+          headers: new Headers({
+            host: 'http://localhost:3000',
+          }),
+        };
+        const url = `http://localhost:3001/api${key}`;
 
-      //@ts-expect-error - fetch
-      global.fetch = jest.fn((url, p) => {
-        if (p) {
-          params = new Request(url, p);
-        }
-        return Promise.resolve({ status: 200 });
+        (global.fetch as jest.Mock) = jest.fn((url, p) => {
+          if (p) {
+            params = new Request(url, p);
+          }
+          return Promise.resolve({ status: 200 });
+        });
+
+        const fn = await apiGet(new Request(url, init));
+
+        expect(fn).toBeTruthy();
+        expect((fn as Response)?.status).toEqual(200);
+        params.headers.forEach((value, key) => {
+          if (key !== 'content-type') {
+            headersArray.push({ key, value });
+          }
+        });
+        expect(headersArray).toEqual([
+          { key: 'host', value: 'localhost:3001' },
+          { key: HEADER_ORIGIN, value: 'http://localhost:3001' },
+          { key: HEADER_SECURE_COOKIES, value: 'false' },
+        ]);
       });
-
-      const fn = await apiGet(req as unknown as Request);
-
-      expect(fn).toBeTruthy();
-      expect(fn?.status).toEqual(200);
-      params.headers.forEach((value, key) => {
-        if (key !== 'content-type') {
-          headersArray.push({ key, value });
-        }
-      });
-      expect(headersArray).toEqual([
-        { key: 'host', value: 'localhost:3001' },
-        { key: HEADER_ORIGIN, value: 'http://localhost:3001' },
-        { key: HEADER_SECURE_COOKIES, value: 'false' },
-      ]);
     });
-  });
 });

--- a/packages/server/src/api/handlers/PUT.ts
+++ b/packages/server/src/api/handlers/PUT.ts
@@ -13,10 +13,30 @@ import invite, {
 import { handlePasswordReset, matchesPasswordReset } from '../routes/auth';
 import { Routes } from '../types';
 import { Config } from '../../utils/Config';
+import { ExtensionState } from '../../types';
 
 export default function PUTER(configRoutes: Routes, config: Config) {
-  const { info, warn } = config.logger('[PUT MATCHER]');
-  return async function PUT(req: Request) {
+  const { error, info, warn } = config.logger('[PUT MATCHER]');
+  return async function PUT(...params: unknown[]) {
+    const handledRequest = await config.extensionCtx?.runExtensions(
+      ExtensionState.onHandleRequest,
+      config,
+      params
+    );
+    // if this has been overridden, we don't do anything else.
+    // for express, when you do this, make a new internal instance that does not have
+    // `onHandleRequest`
+    if (handledRequest) {
+      return handledRequest;
+    }
+
+    // the default
+    const req = params[0] instanceof Request ? params[0] : null;
+    if (!req) {
+      error('Proxy requests failed, a Request object was not passed.');
+      return;
+    }
+
     // order matters for tenantInvites
     if (matchesInvite(configRoutes, req)) {
       info('matches tenant invite');

--- a/packages/server/src/api/routes/auth/callback.ts
+++ b/packages/server/src/api/routes/auth/callback.ts
@@ -27,7 +27,7 @@ export default async function route(req: Request, config: Config) {
       error('an error as occurred', e);
     });
 
-    const location = res?.headers.get('location');
+    const location = res?.headers?.get('location');
     if (location) {
       return new Response(res?.body, {
         status: 302,

--- a/packages/server/src/api/routes/auth/password-reset.ts
+++ b/packages/server/src/api/routes/auth/password-reset.ts
@@ -16,7 +16,7 @@ export default async function route(req: Request, config: Config) {
     config
   );
 
-  const location = res?.headers.get('location');
+  const location = res?.headers?.get('location');
   if (location) {
     return new Response(res?.body, {
       status: 302,

--- a/packages/server/src/api/routes/auth/signin.ts
+++ b/packages/server/src/api/routes/auth/signin.ts
@@ -53,6 +53,7 @@ export default async function route(req: Request, config: Config) {
   const params = new URLSearchParams(passThroughUrl.search);
 
   url = `${url}${params.toString() !== '' ? `?${params.toString()}` : ''}`;
+
   const res = await request(url, { ...init, request: req }, config);
 
   return res;
@@ -73,6 +74,5 @@ export async function fetchSignIn(
     headers: config.headers,
     body,
   });
-
   return (await config.handlers.POST(req)) as Response;
 }

--- a/packages/server/src/api/routes/auth/verify-email.ts
+++ b/packages/server/src/api/routes/auth/verify-email.ts
@@ -16,7 +16,7 @@ export default async function route(req: Request, config: Config) {
     config
   );
 
-  const location = res?.headers.get('location');
+  const location = res?.headers?.get('location');
   if (location) {
     return new Response(res?.body, {
       status: 302,

--- a/packages/server/src/api/routes/tenants/[tenantId]/invite/PUT.ts
+++ b/packages/server/src/api/routes/tenants/[tenantId]/invite/PUT.ts
@@ -53,7 +53,7 @@ export async function PUT(
   const url = `${apiRoutes(config).INVITE(tenantId)}`;
 
   const res = await request(url, init, config);
-  const location = res?.headers.get('location');
+  const location = res?.headers?.get('location');
   if (location) {
     return new Response(res?.body, {
       status: 302,

--- a/packages/server/src/api/routes/tenants/[tenantId]/users/[userId]/index.ts
+++ b/packages/server/src/api/routes/tenants/[tenantId]/users/[userId]/index.ts
@@ -37,6 +37,7 @@ export default async function route(request: Request, config: Config) {
 
 export function matches(configRoutes: Routes, request: Request): boolean {
   const url = new URL(request.url);
+  // `link` may be on the end of this.
   const [, userId, possibleTenantId, tenantId] = url.pathname
     .split('/')
     .reverse();

--- a/packages/server/src/api/utils/auth.ts
+++ b/packages/server/src/api/utils/auth.ts
@@ -59,16 +59,13 @@ export default async function auth(
   req.headers.delete('content-length');
 
   const res = await request(sessionUrl, { request: req }, config);
-  if (!res) {
-    info('no session found');
-    return undefined;
-  }
-  info('session active');
   try {
     const session = await new Response(res.body).json();
     if (Object.keys(session).length === 0) {
+      info('no session found');
       return undefined;
     }
+    info('session active');
     return session;
   } catch (e) {
     error(e);

--- a/packages/server/src/api/utils/request.test.ts
+++ b/packages/server/src/api/utils/request.test.ts
@@ -8,7 +8,7 @@ describe('request', () => {
     jest.resetAllMocks();
   });
 
-  fit('sets the correct GET headers', async () => {
+  it('sets the correct GET headers', async () => {
     global.fetch = jest.fn((url, p) => {
       return Promise.resolve({
         ...p,
@@ -53,11 +53,12 @@ describe('request', () => {
       host: 'localhost:3001',
       'nile-origin': 'http://localhost:3001',
       'content-type': 'application/x-www-form-urlencoded',
+      'nile-secure-cookies': 'false',
     };
     const headersObject = Object.entries(
       Object.fromEntries(res.headers.entries())
     );
-    expect(headersObject.length).toBe(3);
+    expect(headersObject.length).toBe(4);
     for (const [key, value] of headersObject) {
       const val = expectedHeaders[key];
       expect(value).toBe(val);
@@ -84,12 +85,13 @@ describe('request', () => {
       host: 'localhost:3001',
       'nile-origin': 'http://localhost:3001',
       'content-type': 'application/json',
+      'nile-secure-cookies': 'false',
     };
     const headersObject = Object.entries(
       Object.fromEntries(res.headers.entries())
     );
 
-    expect(headersObject.length).toBe(3);
+    expect(headersObject.length).toBe(4);
     for (const [key, value] of headersObject) {
       const val = expectedHeaders[key];
       expect(value).toBe(val);

--- a/packages/server/src/auth/auth.test.ts
+++ b/packages/server/src/auth/auth.test.ts
@@ -16,6 +16,14 @@ jest.mock('../api/routes/auth/signin');
 jest.mock('../api/routes/auth/signout');
 jest.mock('../api/routes/signup');
 jest.mock('../utils/Event');
+jest.mock('../utils/Logger', () => ({
+  __esModule: true,
+  default: jest.fn(() => () => ({
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  })),
+}));
 
 const mockHeaders = new Headers();
 mockHeaders.set(

--- a/packages/server/src/auth/index.ts
+++ b/packages/server/src/auth/index.ts
@@ -457,11 +457,15 @@ export default class Auth {
 
     const providers = await this.listProviders();
     info('Obtaining csrf');
-    const csrf = await this.getCsrf();
+    const csrf = await this.getCsrf<{ csrfToken: string; headers: Headers }>();
 
     let csrfToken;
     if ('csrfToken' in csrf) {
       csrfToken = csrf.csrfToken;
+      // const parsedCookie = csrf.headers.get('cookie');
+      // if (parsedCookie) {
+      // this.#config.headers.set('cookie', parsedCookie);
+      // }
     } else {
       throw new Error('Unable to obtain parse CSRF. Request blocked.');
     }
@@ -483,6 +487,9 @@ export default class Auth {
 
     info(`Obtaining providers for ${email}`);
     info(`Attempting sign in with email ${email}`);
+    if (!email) {
+      throw new Error('Email missing from payload, unable to sign in');
+    }
     const body = JSON.stringify({
       email,
       password,
@@ -596,7 +603,7 @@ export function parseToken(headers?: Headers) {
 /**
  * Internal helper for the password reset flow.
  */
-function parseResetToken(headers: Headers | void): string | void {
+export function parseResetToken(headers: Headers | void): string | void {
   let authCookie = headers?.get('set-cookie');
   if (!authCookie) {
     authCookie = headers?.get('cookie');

--- a/packages/server/src/auth/obtainCsrf.ts
+++ b/packages/server/src/auth/obtainCsrf.ts
@@ -12,6 +12,7 @@ export default async function obtainCsrf<T = Response | { csrfToken: string }>(
   // we're gonna use it, so set the headers now.
   const csrfCook = parseCSRF(res.headers);
 
+  const h = new Headers();
   // prefer the csrf from the headers over the saved one
   if (csrfCook) {
     const [, value] = csrfCook.split('=');
@@ -27,7 +28,8 @@ export default async function obtainCsrf<T = Response | { csrfToken: string }>(
         .filter(Boolean)
         .join('; ');
       config.headers.set('cookie', cookie);
-      updateHeaders(new Headers({ cookie }));
+      h.set('cookie', cookie);
+      updateHeaders(h);
     }
     if (!rawResponse) {
       return { csrfToken: token };
@@ -54,11 +56,9 @@ export default async function obtainCsrf<T = Response | { csrfToken: string }>(
     config.headers.set('cookie', cookie);
     updateHeaders(new Headers({ cookie }));
   }
-
   if (rawResponse) {
     return res as T;
   }
-
   try {
     return (await res.clone().json()) as T;
   } catch {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -4,7 +4,7 @@ export * from './tenants/types';
 export { JWT, ActiveSession, Providers } from './api/utils/auth';
 
 export { create as Nile, Server } from './Server';
-export { parseCSRF, parseCallback, parseToken } from './auth';
+export { parseCSRF, parseCallback, parseToken, parseResetToken } from './auth';
 export {
   TENANT_COOKIE,
   USER_COOKIE,

--- a/packages/server/src/utils/Config/Config.test.ts
+++ b/packages/server/src/utils/Config/Config.test.ts
@@ -2,6 +2,15 @@ import { NileConfig } from '../../types';
 
 import { Config } from '.';
 
+jest.mock('../Logger', () => ({
+  __esModule: true,
+  default: jest.fn(() => () => ({
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  })),
+}));
+
 describe('Config', () => {
   const ORIGINAL_ENV = process.env;
 

--- a/packages/server/src/utils/Config/index.ts
+++ b/packages/server/src/utils/Config/index.ts
@@ -1,15 +1,30 @@
 import Handlers from '../../api/handlers';
 import { appRoutes } from '../../api/utils/routes';
 import { Routes } from '../../api/types';
-import { NilePoolConfig, NileConfig, Extension } from '../../types';
+import {
+  NilePoolConfig,
+  NileConfig,
+  Extension,
+  ExtensionState,
+  RouteFunctions,
+} from '../../types';
 import Logger, { LogReturn } from '../Logger';
 
-type ExtensionCtx = {
-  handleOnRequest: (
+export type ConfigurablePaths = {
+  get: string[];
+  post: string[];
+  delete: string[];
+  put: string[];
+};
+export type ExtensionReturns = void | Response | Request | ExtensionState;
+export type ExtensionCtx = {
+  runExtensions: <T = ExtensionReturns>(
+    toRun: ExtensionState,
     config: Config,
-    _init: RequestInit & { request: Request },
-    params: RequestInit
-  ) => Promise<void>;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    params: any,
+    _init?: RequestInit & { request: Request }
+  ) => Promise<T>;
 };
 type ConfigConstructor = NileConfig & { extensionCtx?: ExtensionCtx };
 import {
@@ -26,18 +41,8 @@ import {
 
 export class Config {
   routes: Routes;
-  handlers: {
-    GET: (req: Request) => Promise<void | Response>;
-    POST: (req: Request) => Promise<void | Response>;
-    DELETE: (req: Request) => Promise<void | Response>;
-    PUT: (req: Request) => Promise<void | Response>;
-  };
-  paths: {
-    get: string[];
-    post: string[];
-    delete: string[];
-    put: string[];
-  };
+  handlers: RouteFunctions;
+  paths: ConfigurablePaths;
   extensionCtx: ExtensionCtx;
   extensions?: Extension[];
   logger: LogReturn;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3255,6 +3255,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@niledatabase/express@workspace:packages/express"
   dependencies:
+    "@types/express": "npm:^5"
+    express: "npm:^5.1.0"
     jest: "npm:^29.7.0"
     ts-jest: "npm:^29.3.4"
     tsup: "npm:^8.5.0"
@@ -5995,6 +5997,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/body-parser@npm:*":
+  version: 1.19.6
+  resolution: "@types/body-parser@npm:1.19.6"
+  dependencies:
+    "@types/connect": "npm:*"
+    "@types/node": "npm:*"
+  checksum: 10/33041e88eae00af2cfa0827e951e5f1751eafab2a8b6fce06cd89ef368a988907996436b1325180edaeddd1c0c7d0d0d4c20a6c9ff294a91e0039a9db9e9b658
+  languageName: node
+  linkType: hard
+
+"@types/connect@npm:*":
+  version: 3.4.38
+  resolution: "@types/connect@npm:3.4.38"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10/7eb1bc5342a9604facd57598a6c62621e244822442976c443efb84ff745246b10d06e8b309b6e80130026a396f19bf6793b7cecd7380169f369dac3bfc46fb99
+  languageName: node
+  linkType: hard
+
 "@types/doctrine@npm:^0.0.9":
   version: 0.0.9
   resolution: "@types/doctrine@npm:0.0.9"
@@ -6046,6 +6067,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/express-serve-static-core@npm:^5.0.0":
+  version: 5.0.6
+  resolution: "@types/express-serve-static-core@npm:5.0.6"
+  dependencies:
+    "@types/node": "npm:*"
+    "@types/qs": "npm:*"
+    "@types/range-parser": "npm:*"
+    "@types/send": "npm:*"
+  checksum: 10/9dc51bdee7da9ad4792e97dd1be5b3071b5128f26d3b87a753070221bb36c8f9d16074b95a8b972acc965641e987b1e279a44675e7312ac8f3e18ec9abe93940
+  languageName: node
+  linkType: hard
+
+"@types/express@npm:^5":
+  version: 5.0.3
+  resolution: "@types/express@npm:5.0.3"
+  dependencies:
+    "@types/body-parser": "npm:*"
+    "@types/express-serve-static-core": "npm:^5.0.0"
+    "@types/serve-static": "npm:*"
+  checksum: 10/bb6f10c14c8e3cce07f79ee172688aa9592852abd7577b663cd0c2054307f172c2b2b36468c918fed0d4ac359b99695807b384b3da6157dfa79acbac2226b59b
+  languageName: node
+  linkType: hard
+
 "@types/glob@npm:^7.1.1":
   version: 7.2.0
   resolution: "@types/glob@npm:7.2.0"
@@ -6069,6 +6113,13 @@ __metadata:
   version: 6.1.0
   resolution: "@types/html-minifier-terser@npm:6.1.0"
   checksum: 10/06bb3e1e8ebff43602c826d67f53f1fd3a6b9c751bfbc67d7ea4e85679446a639e20e60adad8c9d44ab4baf1337b3861b91e7e5e2be798575caf0cc1a5712552
+  languageName: node
+  linkType: hard
+
+"@types/http-errors@npm:*":
+  version: 2.0.5
+  resolution: "@types/http-errors@npm:2.0.5"
+  checksum: 10/a88da669366bc483e8f3b3eb3d34ada5f8d13eeeef851b1204d77e2ba6fc42aba4566d877cca5c095204a3f4349b87fe397e3e21288837bdd945dd514120755b
   languageName: node
   linkType: hard
 
@@ -6215,6 +6266,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/qs@npm:*":
+  version: 6.14.0
+  resolution: "@types/qs@npm:6.14.0"
+  checksum: 10/1909205514d22b3cbc7c2314e2bd8056d5f05dfb21cf4377f0730ee5e338ea19957c41735d5e4806c746176563f50005bbab602d8358432e25d900bdf4970826
+  languageName: node
+  linkType: hard
+
+"@types/range-parser@npm:*":
+  version: 1.2.7
+  resolution: "@types/range-parser@npm:1.2.7"
+  checksum: 10/95640233b689dfbd85b8c6ee268812a732cf36d5affead89e806fe30da9a430767af8ef2cd661024fd97e19d61f3dec75af2df5e80ec3bea000019ab7028629a
+  languageName: node
+  linkType: hard
+
 "@types/react-dom@npm:^18.0.0":
   version: 18.3.5
   resolution: "@types/react-dom@npm:18.3.5"
@@ -6260,6 +6325,27 @@ __metadata:
   version: 7.5.8
   resolution: "@types/semver@npm:7.5.8"
   checksum: 10/3496808818ddb36deabfe4974fd343a78101fa242c4690044ccdc3b95dcf8785b494f5d628f2f47f38a702f8db9c53c67f47d7818f2be1b79f2efb09692e1178
+  languageName: node
+  linkType: hard
+
+"@types/send@npm:*":
+  version: 0.17.5
+  resolution: "@types/send@npm:0.17.5"
+  dependencies:
+    "@types/mime": "npm:^1"
+    "@types/node": "npm:*"
+  checksum: 10/b68ae8f9ba9328a4f276cd010914ed43b96371fbf34c7aa08a9111bff36661810bb14b96647e4a92e319dbd2689dc107fb0f9194ec3fa9335c162dc134026240
+  languageName: node
+  linkType: hard
+
+"@types/serve-static@npm:*":
+  version: 1.15.8
+  resolution: "@types/serve-static@npm:1.15.8"
+  dependencies:
+    "@types/http-errors": "npm:*"
+    "@types/node": "npm:*"
+    "@types/send": "npm:*"
+  checksum: 10/c031f870df6056a4c0a5a0ae94c5584006ab55400c74ae44de4d68d89338fbe982422861bad478b89a073f671efca454689fd28b6147358d6adc8edbc599caea
   languageName: node
   linkType: hard
 
@@ -6890,6 +6976,16 @@ __metadata:
   version: 3.0.0
   resolution: "abbrev@npm:3.0.0"
   checksum: 10/2ceee14efdeda42ef7355178c1069499f183546ff7112b3efe79c1edef09d20ad9c17939752215fb8f7fcf48d10e6a7c0aa00136dc9cf4d293d963718bb1d200
+  languageName: node
+  linkType: hard
+
+"accepts@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "accepts@npm:2.0.0"
+  dependencies:
+    mime-types: "npm:^3.0.0"
+    negotiator: "npm:^1.0.0"
+  checksum: 10/ea1343992b40b2bfb3a3113fa9c3c2f918ba0f9197ae565c48d3f84d44b174f6b1d5cd9989decd7655963eb03a272abc36968cc439c2907f999bd5ef8653d5a7
   languageName: node
   linkType: hard
 
@@ -7788,6 +7884,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"body-parser@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "body-parser@npm:2.2.0"
+  dependencies:
+    bytes: "npm:^3.1.2"
+    content-type: "npm:^1.0.5"
+    debug: "npm:^4.4.0"
+    http-errors: "npm:^2.0.0"
+    iconv-lite: "npm:^0.6.3"
+    on-finished: "npm:^2.4.1"
+    qs: "npm:^6.14.0"
+    raw-body: "npm:^3.0.0"
+    type-is: "npm:^2.0.0"
+  checksum: 10/e9d844b036bd15970df00a16f373c7ed28e1ef870974a0a1d4d6ef60d70e01087cc20a0dbb2081c49a88e3c08ce1d87caf1e2898c615dffa193f63e8faa8a84e
+  languageName: node
+  linkType: hard
+
 "boolbase@npm:^1.0.0":
   version: 1.0.0
   resolution: "boolbase@npm:1.0.0"
@@ -7919,6 +8032,13 @@ __metadata:
   version: 7.0.0
   resolution: "byte-size@npm:7.0.0"
   checksum: 10/aacb46f2dfa46a3a10ce523689afedea4043e20c1206f7f42beabb120460635e603e337bc5dd3acacfa9b9b698f1d15d7f13cb350a296ea75a622b420363ef43
+  languageName: node
+  linkType: hard
+
+"bytes@npm:3.1.2, bytes@npm:^3.1.2":
+  version: 3.1.2
+  resolution: "bytes@npm:3.1.2"
+  checksum: 10/a10abf2ba70c784471d6b4f58778c0beeb2b5d405148e66affa91f23a9f13d07603d0a0354667310ae1d6dc141474ffd44e2a074be0f6e2254edb8fc21445388
   languageName: node
   linkType: hard
 
@@ -8769,6 +8889,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"content-disposition@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "content-disposition@npm:1.0.0"
+  dependencies:
+    safe-buffer: "npm:5.2.1"
+  checksum: 10/0dcc1a2d7874526b0072df3011b134857b49d97a3bc135bb464a299525d4972de6f5f464fd64da6c4d8406d26a1ffb976f62afaffef7723b1021a44498d10e08
+  languageName: node
+  linkType: hard
+
+"content-type@npm:^1.0.5":
+  version: 1.0.5
+  resolution: "content-type@npm:1.0.5"
+  checksum: 10/585847d98dc7fb8035c02ae2cb76c7a9bd7b25f84c447e5ed55c45c2175e83617c8813871b4ee22f368126af6b2b167df655829007b21aa10302873ea9c62662
+  languageName: node
+  linkType: hard
+
 "conventional-changelog-angular@npm:5.0.12":
   version: 5.0.12
   resolution: "conventional-changelog-angular@npm:5.0.12"
@@ -8914,6 +9050,20 @@ __metadata:
   version: 1.2.2
   resolution: "cookie-es@npm:1.2.2"
   checksum: 10/0fd742c11caa185928e450543f84df62d4b2c1fc7b5041196b57b7db04e1c6ac6585fb40e4f579a2819efefd2d6a9cbb4d17f71240d05f4dcd8f74ae81341a20
+  languageName: node
+  linkType: hard
+
+"cookie-signature@npm:^1.2.1":
+  version: 1.2.2
+  resolution: "cookie-signature@npm:1.2.2"
+  checksum: 10/be44a3c9a56f3771aea3a8bd8ad8f0a8e2679bcb967478267f41a510b4eb5ec55085386ba79c706c4ac21605ca76f4251973444b90283e0eb3eeafe8a92c7708
+  languageName: node
+  linkType: hard
+
+"cookie@npm:^0.7.1":
+  version: 0.7.2
+  resolution: "cookie@npm:0.7.2"
+  checksum: 10/24b286c556420d4ba4e9bc09120c9d3db7d28ace2bd0f8ccee82422ce42322f73c8312441271e5eefafbead725980e5996cc02766dbb89a90ac7f5636ede608f
   languageName: node
   linkType: hard
 
@@ -9285,6 +9435,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"debug@npm:^4.3.5":
+  version: 4.4.1
+  resolution: "debug@npm:4.4.1"
+  dependencies:
+    ms: "npm:^2.1.3"
+  peerDependenciesMeta:
+    supports-color:
+      optional: true
+  checksum: 10/8e2709b2144f03c7950f8804d01ccb3786373df01e406a0f66928e47001cf2d336cbed9ee137261d4f90d68d8679468c755e3548ed83ddacdc82b194d2468afe
+  languageName: node
+  linkType: hard
+
 "decamelize-keys@npm:^1.1.0":
   version: 1.1.1
   resolution: "decamelize-keys@npm:1.1.1"
@@ -9458,6 +9620,13 @@ __metadata:
   version: 1.0.0
   resolution: "delegates@npm:1.0.0"
   checksum: 10/a51744d9b53c164ba9c0492471a1a2ffa0b6727451bdc89e31627fdf4adda9d51277cfcbfb20f0a6f08ccb3c436f341df3e92631a3440226d93a8971724771fd
+  languageName: node
+  linkType: hard
+
+"depd@npm:2.0.0, depd@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "depd@npm:2.0.0"
+  checksum: 10/c0c8ff36079ce5ada64f46cc9d6fd47ebcf38241105b6e0c98f412e8ad91f084bcf906ff644cc3a4bd876ca27a62accb8b0fff72ea6ed1a414b89d8506f4a5ca
   languageName: node
   linkType: hard
 
@@ -9820,6 +9989,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ee-first@npm:1.1.1":
+  version: 1.1.1
+  resolution: "ee-first@npm:1.1.1"
+  checksum: 10/1b4cac778d64ce3b582a7e26b218afe07e207a0f9bfe13cc7395a6d307849cfe361e65033c3251e00c27dd060cab43014c2d6b2647676135e18b77d2d05b3f4f
+  languageName: node
+  linkType: hard
+
 "ejs@npm:^3.1.10, ejs@npm:^3.1.7":
   version: 3.1.10
   resolution: "ejs@npm:3.1.10"
@@ -9856,6 +10032,13 @@ __metadata:
   version: 9.2.2
   resolution: "emoji-regex@npm:9.2.2"
   checksum: 10/915acf859cea7131dac1b2b5c9c8e35c4849e325a1d114c30adb8cd615970f6dca0e27f64f3a4949d7d6ed86ecd79a1c5c63f02e697513cddd7b5835c90948b8
+  languageName: node
+  linkType: hard
+
+"encodeurl@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "encodeurl@npm:2.0.0"
+  checksum: 10/abf5cd51b78082cf8af7be6785813c33b6df2068ce5191a40ca8b1afe6a86f9230af9a9ce694a5ce4665955e5c1120871826df9c128a642e09c58d592e2807fe
   languageName: node
   linkType: hard
 
@@ -10312,6 +10495,13 @@ __metadata:
   version: 3.2.0
   resolution: "escalade@npm:3.2.0"
   checksum: 10/9d7169e3965b2f9ae46971afa392f6e5a25545ea30f2e2dd99c9b0a95a3f52b5653681a84f5b2911a413ddad2d7a93d3514165072f349b5ffc59c75a899970d6
+  languageName: node
+  linkType: hard
+
+"escape-html@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "escape-html@npm:1.0.3"
+  checksum: 10/6213ca9ae00d0ab8bccb6d8d4e0a98e76237b2410302cf7df70aaa6591d509a2a37ce8998008cbecae8fc8ffaadf3fb0229535e6a145f3ce0b211d060decbb24
   languageName: node
   linkType: hard
 
@@ -10837,6 +11027,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"etag@npm:^1.8.1":
+  version: 1.8.1
+  resolution: "etag@npm:1.8.1"
+  checksum: 10/571aeb3dbe0f2bbd4e4fadbdb44f325fc75335cd5f6f6b6a091e6a06a9f25ed5392f0863c5442acb0646787446e816f13cbfc6edce5b07658541dff573cab1ff
+  languageName: node
+  linkType: hard
+
 "eventemitter3@npm:^4.0.4":
   version: 4.0.7
   resolution: "eventemitter3@npm:4.0.7"
@@ -10950,6 +11147,41 @@ __metadata:
   version: 3.1.2
   resolution: "exponential-backoff@npm:3.1.2"
   checksum: 10/ca2f01f1aa4dafd3f3917bd531ab5be08c6f5f4b2389d2e974f903de3cbeb50b9633374353516b6afd70905775e33aba11afab1232d3acf0aa2963b98a611c51
+  languageName: node
+  linkType: hard
+
+"express@npm:^5.1.0":
+  version: 5.1.0
+  resolution: "express@npm:5.1.0"
+  dependencies:
+    accepts: "npm:^2.0.0"
+    body-parser: "npm:^2.2.0"
+    content-disposition: "npm:^1.0.0"
+    content-type: "npm:^1.0.5"
+    cookie: "npm:^0.7.1"
+    cookie-signature: "npm:^1.2.1"
+    debug: "npm:^4.4.0"
+    encodeurl: "npm:^2.0.0"
+    escape-html: "npm:^1.0.3"
+    etag: "npm:^1.8.1"
+    finalhandler: "npm:^2.1.0"
+    fresh: "npm:^2.0.0"
+    http-errors: "npm:^2.0.0"
+    merge-descriptors: "npm:^2.0.0"
+    mime-types: "npm:^3.0.0"
+    on-finished: "npm:^2.4.1"
+    once: "npm:^1.4.0"
+    parseurl: "npm:^1.3.3"
+    proxy-addr: "npm:^2.0.7"
+    qs: "npm:^6.14.0"
+    range-parser: "npm:^1.2.1"
+    router: "npm:^2.2.0"
+    send: "npm:^1.1.0"
+    serve-static: "npm:^2.2.0"
+    statuses: "npm:^2.0.1"
+    type-is: "npm:^2.0.1"
+    vary: "npm:^1.1.2"
+  checksum: 10/6dba00bbdf308f43a84ed3f07a7e9870d5208f2a0b8f60f39459dda089750379747819863fad250849d3c9163833f33f94ce69d73938df31e0c5a430800d7e56
   languageName: node
   linkType: hard
 
@@ -11147,6 +11379,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"finalhandler@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "finalhandler@npm:2.1.0"
+  dependencies:
+    debug: "npm:^4.4.0"
+    encodeurl: "npm:^2.0.0"
+    escape-html: "npm:^1.0.3"
+    on-finished: "npm:^2.4.1"
+    parseurl: "npm:^1.3.3"
+    statuses: "npm:^2.0.1"
+  checksum: 10/b2bd68c310e2c463df0ab747ab05f8defbc540b8c3f2442f86e7d084ac8acbc31f8cae079931b7f5a406521501941e3395e963de848a0aaf45dd414adeb5ff4e
+  languageName: node
+  linkType: hard
+
 "find-cache-dir@npm:^3.3.1, find-cache-dir@npm:^3.3.2":
   version: 3.3.2
   resolution: "find-cache-dir@npm:3.3.2"
@@ -11309,10 +11555,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"forwarded@npm:0.2.0":
+  version: 0.2.0
+  resolution: "forwarded@npm:0.2.0"
+  checksum: 10/29ba9fd347117144e97cbb8852baae5e8b2acb7d1b591ef85695ed96f5b933b1804a7fac4a15dd09ca7ac7d0cdc104410e8102aae2dd3faa570a797ba07adb81
+  languageName: node
+  linkType: hard
+
 "fraction.js@npm:^4.3.7":
   version: 4.3.7
   resolution: "fraction.js@npm:4.3.7"
   checksum: 10/bb5ebcdeeffcdc37b68ead3bdfc244e68de188e0c64e9702197333c72963b95cc798883ad16adc21588088b942bca5b6a6ff4aeb1362d19f6f3b629035dc15f5
+  languageName: node
+  linkType: hard
+
+"fresh@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "fresh@npm:2.0.0"
+  checksum: 10/44e1468488363074641991c1340d2a10c5a6f6d7c353d89fd161c49d120c58ebf9890720f7584f509058385836e3ce50ddb60e9f017315a4ba8c6c3461813bfc
   languageName: node
   linkType: hard
 
@@ -12154,6 +12414,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"http-errors@npm:2.0.0, http-errors@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "http-errors@npm:2.0.0"
+  dependencies:
+    depd: "npm:2.0.0"
+    inherits: "npm:2.0.4"
+    setprototypeof: "npm:1.2.0"
+    statuses: "npm:2.0.1"
+    toidentifier: "npm:1.0.1"
+  checksum: 10/0e7f76ee8ff8a33e58a3281a469815b893c41357378f408be8f6d4aa7d1efafb0da064625518e7078381b6a92325949b119dc38fcb30bdbc4e3a35f78c44c439
+  languageName: node
+  linkType: hard
+
 "http-proxy-agent@npm:^5.0.0":
   version: 5.0.0
   resolution: "http-proxy-agent@npm:5.0.0"
@@ -12241,7 +12514,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"iconv-lite@npm:0.6.3, iconv-lite@npm:^0.6.2":
+"iconv-lite@npm:0.6.3, iconv-lite@npm:^0.6.2, iconv-lite@npm:^0.6.3":
   version: 0.6.3
   resolution: "iconv-lite@npm:0.6.3"
   dependencies:
@@ -12353,7 +12626,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"inherits@npm:2, inherits@npm:^2.0.3, inherits@npm:^2.0.4, inherits@npm:~2.0.3":
+"inherits@npm:2, inherits@npm:2.0.4, inherits@npm:^2.0.3, inherits@npm:^2.0.4, inherits@npm:~2.0.3":
   version: 2.0.4
   resolution: "inherits@npm:2.0.4"
   checksum: 10/cd45e923bee15186c07fa4c89db0aace24824c482fb887b528304694b2aa6ff8a898da8657046a5dcf3e46cd6db6c61629551f9215f208d7c3f157cf9b290521
@@ -12453,6 +12726,13 @@ __metadata:
     jsbn: "npm:1.1.0"
     sprintf-js: "npm:^1.1.3"
   checksum: 10/1ed81e06721af012306329b31f532b5e24e00cb537be18ddc905a84f19fe8f83a09a1699862bf3a1ec4b9dea93c55a3fa5faf8b5ea380431469df540f38b092c
+  languageName: node
+  linkType: hard
+
+"ipaddr.js@npm:1.9.1":
+  version: 1.9.1
+  resolution: "ipaddr.js@npm:1.9.1"
+  checksum: 10/864d0cced0c0832700e9621913a6429ccdc67f37c1bd78fb8c6789fff35c9d167cb329134acad2290497a53336813ab4798d2794fd675d5eb33b5fdf0982b9ca
   languageName: node
   linkType: hard
 
@@ -12770,6 +13050,13 @@ __metadata:
   version: 1.0.1
   resolution: "is-potential-custom-element-name@npm:1.0.1"
   checksum: 10/ced7bbbb6433a5b684af581872afe0e1767e2d1146b2207ca0068a648fb5cab9d898495d1ac0583524faaf24ca98176a7d9876363097c2d14fee6dd324f3a1ab
+  languageName: node
+  linkType: hard
+
+"is-promise@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "is-promise@npm:4.0.0"
+  checksum: 10/0b46517ad47b00b6358fd6553c83ec1f6ba9acd7ffb3d30a0bf519c5c69e7147c132430452351b8a9fc198f8dd6c4f76f8e6f5a7f100f8c77d57d9e0f4261a8a
   languageName: node
   linkType: hard
 
@@ -14548,6 +14835,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"media-typer@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "media-typer@npm:1.1.0"
+  checksum: 10/a58dd60804df73c672942a7253ccc06815612326dc1c0827984b1a21704466d7cde351394f47649e56cf7415e6ee2e26e000e81b51b3eebb5a93540e8bf93cbd
+  languageName: node
+  linkType: hard
+
 "memfs@npm:^3.4.1, memfs@npm:^3.4.12":
   version: 3.5.3
   resolution: "memfs@npm:3.5.3"
@@ -14582,6 +14876,13 @@ __metadata:
     type-fest: "npm:^0.18.0"
     yargs-parser: "npm:^20.2.3"
   checksum: 10/d4770f90135c0ef4d0f4fa4f4310a18c07bbbe408221fa79a68fda93944134001ffc24ed605e7668f61e920dd8db30936548e927d2331b0e30699d56247f9873
+  languageName: node
+  linkType: hard
+
+"merge-descriptors@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "merge-descriptors@npm:2.0.0"
+  checksum: 10/e383332e700a94682d0125a36c8be761142a1320fc9feeb18e6e36647c9edf064271645f5669b2c21cf352116e561914fd8aa831b651f34db15ef4038c86696a
   languageName: node
   linkType: hard
 
@@ -14626,12 +14927,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mime-db@npm:^1.54.0":
+  version: 1.54.0
+  resolution: "mime-db@npm:1.54.0"
+  checksum: 10/9e7834be3d66ae7f10eaa69215732c6d389692b194f876198dca79b2b90cbf96688d9d5d05ef7987b20f749b769b11c01766564264ea5f919c88b32a29011311
+  languageName: node
+  linkType: hard
+
 "mime-types@npm:^2.1.12, mime-types@npm:^2.1.27, mime-types@npm:^2.1.31":
   version: 2.1.35
   resolution: "mime-types@npm:2.1.35"
   dependencies:
     mime-db: "npm:1.52.0"
   checksum: 10/89aa9651b67644035de2784a6e665fc685d79aba61857e02b9c8758da874a754aed4a9aced9265f5ed1171fd934331e5516b84a7f0218031b6fa0270eca1e51a
+  languageName: node
+  linkType: hard
+
+"mime-types@npm:^3.0.0, mime-types@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "mime-types@npm:3.0.1"
+  dependencies:
+    mime-db: "npm:^1.54.0"
+  checksum: 10/fa1d3a928363723a8046c346d87bf85d35014dae4285ad70a3ff92bd35957992b3094f8417973cfe677330916c6ef30885109624f1fb3b1e61a78af509dba120
   languageName: node
   linkType: hard
 
@@ -15752,6 +16069,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"on-finished@npm:^2.4.1":
+  version: 2.4.1
+  resolution: "on-finished@npm:2.4.1"
+  dependencies:
+    ee-first: "npm:1.1.1"
+  checksum: 10/8e81472c5028125c8c39044ac4ab8ba51a7cdc19a9fbd4710f5d524a74c6d8c9ded4dd0eed83f28d3d33ac1d7a6a439ba948ccb765ac6ce87f30450a26bfe2ea
+  languageName: node
+  linkType: hard
+
 "once@npm:^1.3.0, once@npm:^1.3.1, once@npm:^1.4.0":
   version: 1.4.0
   resolution: "once@npm:1.4.0"
@@ -16174,6 +16500,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"parseurl@npm:^1.3.3":
+  version: 1.3.3
+  resolution: "parseurl@npm:1.3.3"
+  checksum: 10/407cee8e0a3a4c5cd472559bca8b6a45b82c124e9a4703302326e9ab60fc1081442ada4e02628efef1eb16197ddc7f8822f5a91fd7d7c86b51f530aedb17dfa2
+  languageName: node
+  linkType: hard
+
 "pascal-case@npm:^3.1.2":
   version: 3.1.2
   resolution: "pascal-case@npm:3.1.2"
@@ -16254,6 +16587,13 @@ __metadata:
   version: 3.3.0
   resolution: "path-to-regexp@npm:3.3.0"
   checksum: 10/8d256383af8db66233ee9027cfcbf8f5a68155efbb4f55e784279d3ab206dcaee554ddb72ff0dae97dd2882af9f7fa802634bb7cffa2e796927977e31b829259
+  languageName: node
+  linkType: hard
+
+"path-to-regexp@npm:^8.0.0":
+  version: 8.2.0
+  resolution: "path-to-regexp@npm:8.2.0"
+  checksum: 10/23378276a172b8ba5f5fb824475d1818ca5ccee7bbdb4674701616470f23a14e536c1db11da9c9e6d82b82c556a817bbf4eee6e41b9ed20090ef9427cbb38e13
   languageName: node
   linkType: hard
 
@@ -16912,6 +17252,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"proxy-addr@npm:^2.0.7":
+  version: 2.0.7
+  resolution: "proxy-addr@npm:2.0.7"
+  dependencies:
+    forwarded: "npm:0.2.0"
+    ipaddr.js: "npm:1.9.1"
+  checksum: 10/f24a0c80af0e75d31e3451398670d73406ec642914da11a2965b80b1898ca6f66a0e3e091a11a4327079b2b268795f6fa06691923fef91887215c3d0e8ea3f68
+  languageName: node
+  linkType: hard
+
 "proxy-agent@npm:6.5.0":
   version: 6.5.0
   resolution: "proxy-agent@npm:6.5.0"
@@ -16982,7 +17332,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qs@npm:^6.12.3":
+"qs@npm:^6.12.3, qs@npm:^6.14.0":
   version: 6.14.0
   resolution: "qs@npm:6.14.0"
   dependencies:
@@ -17032,6 +17382,18 @@ __metadata:
   version: 1.2.1
   resolution: "range-parser@npm:1.2.1"
   checksum: 10/ce21ef2a2dd40506893157970dc76e835c78cf56437e26e19189c48d5291e7279314477b06ac38abd6a401b661a6840f7b03bd0b1249da9b691deeaa15872c26
+  languageName: node
+  linkType: hard
+
+"raw-body@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "raw-body@npm:3.0.0"
+  dependencies:
+    bytes: "npm:3.1.2"
+    http-errors: "npm:2.0.0"
+    iconv-lite: "npm:0.6.3"
+    unpipe: "npm:1.0.0"
+  checksum: 10/2443429bbb2f9ae5c50d3d2a6c342533dfbde6b3173740b70fa0302b30914ff400c6d31a46b3ceacbe7d0925dc07d4413928278b494b04a65736fc17ca33e30c
   languageName: node
   linkType: hard
 
@@ -17864,6 +18226,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"router@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "router@npm:2.2.0"
+  dependencies:
+    debug: "npm:^4.4.0"
+    depd: "npm:^2.0.0"
+    is-promise: "npm:^4.0.0"
+    parseurl: "npm:^1.3.3"
+    path-to-regexp: "npm:^8.0.0"
+  checksum: 10/8949bd1d3da5403cc024e2989fee58d7fda0f3ffe9f2dc5b8a192f295f400b3cde307b0b554f7d44851077640f36962ca469a766b3d57410d7d96245a7ba6c91
+  languageName: node
+  linkType: hard
+
 "rspack-resolver@npm:^1.1.0":
   version: 1.2.2
   resolution: "rspack-resolver@npm:1.2.2"
@@ -17962,7 +18337,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"safe-buffer@npm:^5.1.0, safe-buffer@npm:~5.2.0":
+"safe-buffer@npm:5.2.1, safe-buffer@npm:^5.1.0, safe-buffer@npm:~5.2.0":
   version: 5.2.1
   resolution: "safe-buffer@npm:5.2.1"
   checksum: 10/32872cd0ff68a3ddade7a7617b8f4c2ae8764d8b7d884c651b74457967a9e0e886267d3ecc781220629c44a865167b61c375d2da6c720c840ecd73f45d5d9451
@@ -18101,6 +18476,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"send@npm:^1.1.0, send@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "send@npm:1.2.0"
+  dependencies:
+    debug: "npm:^4.3.5"
+    encodeurl: "npm:^2.0.0"
+    escape-html: "npm:^1.0.3"
+    etag: "npm:^1.8.1"
+    fresh: "npm:^2.0.0"
+    http-errors: "npm:^2.0.0"
+    mime-types: "npm:^3.0.1"
+    ms: "npm:^2.1.3"
+    on-finished: "npm:^2.4.1"
+    range-parser: "npm:^1.2.1"
+    statuses: "npm:^2.0.1"
+  checksum: 10/9fa3b1a3b9a06b7b4ab00c25e8228326d9665a9745753a34d1ffab8ac63c7c206727331d1dc5be73647f1b658d259a1aa8e275b0e0eee51349370af02e9da506
+  languageName: node
+  linkType: hard
+
 "serialize-javascript@npm:^4.0.0":
   version: 4.0.0
   resolution: "serialize-javascript@npm:4.0.0"
@@ -18116,6 +18510,18 @@ __metadata:
   dependencies:
     randombytes: "npm:^2.1.0"
   checksum: 10/445a420a6fa2eaee4b70cbd884d538e259ab278200a2ededd73253ada17d5d48e91fb1f4cd224a236ab62ea7ba0a70c6af29fc93b4f3d3078bf7da1c031fde58
+  languageName: node
+  linkType: hard
+
+"serve-static@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "serve-static@npm:2.2.0"
+  dependencies:
+    encodeurl: "npm:^2.0.0"
+    escape-html: "npm:^1.0.3"
+    parseurl: "npm:^1.3.3"
+    send: "npm:^1.2.0"
+  checksum: 10/9f1a900738c5bb02258275ce3bd1273379c4c3072b622e15d44e8f47d89a1ba2d639ec2d63b11c263ca936096b40758acb7a0d989cd6989018a65a12f9433ada
   languageName: node
   linkType: hard
 
@@ -18160,6 +18566,13 @@ __metadata:
     es-errors: "npm:^1.3.0"
     es-object-atoms: "npm:^1.0.0"
   checksum: 10/b87f8187bca595ddc3c0721ece4635015fd9d7cb294e6dd2e394ce5186a71bbfa4dc8a35010958c65e43ad83cde09642660e61a952883c24fd6b45ead15f045c
+  languageName: node
+  linkType: hard
+
+"setprototypeof@npm:1.2.0":
+  version: 1.2.0
+  resolution: "setprototypeof@npm:1.2.0"
+  checksum: 10/fde1630422502fbbc19e6844346778f99d449986b2f9cdcceb8326730d2f3d9964dbcb03c02aaadaefffecd0f2c063315ebea8b3ad895914bf1afc1747fc172e
   languageName: node
   linkType: hard
 
@@ -18644,6 +19057,20 @@ __metadata:
   dependencies:
     escape-string-regexp: "npm:^2.0.0"
   checksum: 10/cdc988acbc99075b4b036ac6014e5f1e9afa7e564482b687da6384eee6a1909d7eaffde85b0a17ffbe186c5247faf6c2b7544e802109f63b72c7be69b13151bb
+  languageName: node
+  linkType: hard
+
+"statuses@npm:2.0.1":
+  version: 2.0.1
+  resolution: "statuses@npm:2.0.1"
+  checksum: 10/18c7623fdb8f646fb213ca4051be4df7efb3484d4ab662937ca6fbef7ced9b9e12842709872eb3020cc3504b93bde88935c9f6417489627a7786f24f8031cbcb
+  languageName: node
+  linkType: hard
+
+"statuses@npm:^2.0.1":
+  version: 2.0.2
+  resolution: "statuses@npm:2.0.2"
+  checksum: 10/6927feb50c2a75b2a4caab2c565491f7a93ad3d8dbad7b1398d52359e9243a20e2ebe35e33726dee945125ef7a515e9097d8a1b910ba2bbd818265a2f6c39879
   languageName: node
   linkType: hard
 
@@ -19415,6 +19842,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"toidentifier@npm:1.0.1":
+  version: 1.0.1
+  resolution: "toidentifier@npm:1.0.1"
+  checksum: 10/952c29e2a85d7123239b5cfdd889a0dde47ab0497f0913d70588f19c53f7e0b5327c95f4651e413c74b785147f9637b17410ac8c846d5d4a20a5a33eb6dc3a45
+  languageName: node
+  linkType: hard
+
 "token-types@npm:^6.0.0":
   version: 6.0.0
   resolution: "token-types@npm:6.0.0"
@@ -19879,6 +20313,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"type-is@npm:^2.0.0, type-is@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "type-is@npm:2.0.1"
+  dependencies:
+    content-type: "npm:^1.0.5"
+    media-typer: "npm:^1.1.0"
+    mime-types: "npm:^3.0.0"
+  checksum: 10/bacdb23c872dacb7bd40fbd9095e6b2fca2895eedbb689160c05534d7d4810a7f4b3fd1ae87e96133c505958f6d602967a68db5ff577b85dd6be76eaa75d58af
+  languageName: node
+  linkType: hard
+
 "typed-array-buffer@npm:^1.0.3":
   version: 1.0.3
   resolution: "typed-array-buffer@npm:1.0.3"
@@ -20152,6 +20597,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"unpipe@npm:1.0.0":
+  version: 1.0.0
+  resolution: "unpipe@npm:1.0.0"
+  checksum: 10/4fa18d8d8d977c55cb09715385c203197105e10a6d220087ec819f50cb68870f02942244f1017565484237f1f8c5d3cd413631b1ae104d3096f24fdfde1b4aa2
+  languageName: node
+  linkType: hard
+
 "unplugin@npm:^1.3.1":
   version: 1.16.1
   resolution: "unplugin@npm:1.16.1"
@@ -20352,6 +20804,13 @@ __metadata:
   version: 13.12.0
   resolution: "validator@npm:13.12.0"
   checksum: 10/db6eb0725e2b67d60d30073ae8573982713b5903195d031dc3c7db7e82df8b74e8c13baef8e2106d146d979599fd61a06cde1fec5c148e4abd53d52817ff0fd9
+  languageName: node
+  linkType: hard
+
+"vary@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "vary@npm:1.1.2"
+  checksum: 10/31389debef15a480849b8331b220782230b9815a8e0dbb7b9a8369559aed2e9a7800cd904d4371ea74f4c3527db456dc8e7ac5befce5f0d289014dbdf47b2242
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
this will allow for something like 

```ts
import "dotenv";
import express from "express";
import ViteExpress from "vite-express";
import { Server, Nile } from "@niledatabase/server";
import { express as expressExt } from "@niledatabase/express";

import type { Request, Response, NextFunction } from "express";

type ExpressRouteHandler = (
  req: Request,
  res: Response,
  next: NextFunction
) => void | Promise<void>;

type ExpressRouteFunctions = {
  GET: ExpressRouteHandler;
  POST: ExpressRouteHandler;
  PUT: ExpressRouteHandler;
  DELETE: ExpressRouteHandler;
};
type NileWithExpress = Server & {
  handlers: ExpressRouteFunctions;
};

const app = express();

app.use(express.json());
app.use(express.urlencoded({ extended: true }));

// configure nile with express
const nile = Nile({ extensions: [expressExt], debug: true }) as NileWithExpress;
// surgical paths
app.get(nile.paths.get, nile.handlers.GET);
app.post(nile.paths.post, nile.handlers.POST);
app.put(nile.paths.put, nile.handlers.PUT);
app.delete(nile.paths.delete, nile.handlers.DELETE);
// context middleware for cookies and tenant ids
app.use(nile.setContext);

ViteExpress.listen(app, 3000, () =>
  console.log("Server is listening on port 3000...")
);

```
 in an express app. obviously there's a lot there in the express extension. and you can turn off/on the default routes server side now, there's an `onConfiguration` that is called the 1st time, and the nile factory values are more mutate-able now. There's some type ducking you need to do based on what `expressExt` does, but that's pretty straight forward. 

Still have to test this in our actual express example, but hopefully that's not too bad.
