### PR TITLE
fix(server): sync the context all the time from extensions

### DIFF
--- a/apps/nextjs-kitchensink/app/dashboard/page.tsx
+++ b/apps/nextjs-kitchensink/app/dashboard/page.tsx
@@ -1,6 +1,24 @@
 import { nile } from '../api/[...nile]/nile';
 
 export default async function Dashboard() {
-  const me = await nile.users.getSelf();
-  return <div>{JSON.stringify(me)}</div>;
+  const self1 = await nile.users.getSelf();
+  const [tenants, me] = await nile.withContext(() =>
+    Promise.all([nile.tenants.list(), nile.users.getSelf()])
+  );
+  return (
+    <div className="mx-auto container p-4">
+      <div>no context</div>
+      <pre>
+        <code>{JSON.stringify(self1, null, 2)}</code>
+      </pre>
+      <div>context stuff</div>
+      <pre>
+        <code>{JSON.stringify(me, null, 2)}</code>
+      </pre>
+      <div>Tenants:</div>
+      <pre>
+        <code>{JSON.stringify(tenants, null, 2)}</code>
+      </pre>
+    </div>
+  );
 }

--- a/apps/nextjs-kitchensink/app/tenant-list/ListTenants.tsx
+++ b/apps/nextjs-kitchensink/app/tenant-list/ListTenants.tsx
@@ -1,5 +1,5 @@
 import { ColumnDef } from '@tanstack/react-table';
-import { UserInfo } from '@niledatabase/react';
+import { TenantSelector, UserInfo } from '@niledatabase/react';
 
 import { nile } from '../api/[...nile]/nile';
 
@@ -13,9 +13,12 @@ export default async function ListTenants() {
     return null;
   }
   return (
-    <div className="flex flex-col gap-4">
-      <UserInfo user={me} />
-      <DataTable data={tenants} columns={columns} />
+    <div className="flex flex-col gap-4 items-center">
+      <div className="max-w-3xl border border-muted rounded-xl p-10 w-fit flex flex-col gap-4">
+        <UserInfo user={me} />
+        <TenantSelector className="border border-muted px-4 py-6 rounded-xl" />
+      </div>
+      <DataTable data={tenants} columns={columns} className="w-full" />
     </div>
   );
 }

--- a/apps/nextjs-kitchensink/app/tenant-list/table.tsx
+++ b/apps/nextjs-kitchensink/app/tenant-list/table.tsx
@@ -15,15 +15,18 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
+import { cn } from '@/lib/utils';
 
 interface DataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[];
   data: TData[];
+  className?: string;
 }
 
 export function DataTable<TData, TValue>({
   columns,
   data,
+  className,
 }: DataTableProps<TData, TValue>) {
   const table = useReactTable({
     data,
@@ -32,7 +35,7 @@ export function DataTable<TData, TValue>({
   });
 
   return (
-    <div className="rounded-md border">
+    <div className={cn('rounded-md border', className)}>
       <Table>
         <TableHeader>
           {table.getHeaderGroups().map((headerGroup) => (

--- a/packages/nextjs/src/index.ts
+++ b/packages/nextjs/src/index.ts
@@ -20,7 +20,9 @@ const nextJs: Extension = () => {
   return {
     id: 'next-js-cookies',
     // be sure any server side request gets the headers automatically
-    withContext: nextJsHeaders,
+    withContext: async (ctx: CTX) => {
+      await nextJsHeaders(ctx);
+    },
     // after the response, be sure additional calls have the correct cookies
     onResponse: async ({ response }, { set: setContext }) => {
       const resHeaders = response?.headers;

--- a/packages/server/src/api/utils/extensions.ts
+++ b/packages/server/src/api/utils/extensions.ts
@@ -132,8 +132,20 @@ function mergeCookies(...cookieStrings: (string | null | undefined)[]) {
 }
 
 //just makes typing faster
-export async function runExtensionContext(config: Config) {
-  await config?.extensionCtx?.runExtensions(ExtensionState.withContext, config);
+type ExtensionRunOptions = {
+  skipWithContext?: boolean;
+};
+
+export async function runExtensionContext(
+  config: Config,
+  options?: ExtensionRunOptions
+) {
+  if (!options?.skipWithContext) {
+    await config?.extensionCtx?.runExtensions(
+      ExtensionState.withContext,
+      config
+    );
+  }
 
   await config?.extensionCtx?.runExtensions(
     ExtensionState.withTenantId,

--- a/packages/server/src/api/utils/request-context.test.ts
+++ b/packages/server/src/api/utils/request-context.test.ts
@@ -1,0 +1,40 @@
+import { Config } from '../../utils/Config';
+import { ExtensionState } from '../../types';
+
+import { ctx, withNileContext } from './request-context';
+
+describe('withNileContext', () => {
+  it('applies extension overrides before running callback', async () => {
+    const runExtensionsMock = jest.fn(async (state: ExtensionState) => {
+      if (state === ExtensionState.withContext) {
+        ctx.set({
+          headers: new Headers({ cookie: 'foo=bar' }),
+          tenantId: 'ext-tenant',
+        });
+      }
+    });
+
+    const config = {
+      context: {
+        headers: new Headers(),
+        tenantId: undefined,
+        userId: undefined,
+      },
+      extensions: [jest.fn()],
+      extensionCtx: { runExtensions: runExtensionsMock },
+    } as unknown as Config;
+
+    await ctx.run({ headers: new Headers() }, async () => {
+      await withNileContext(config, async () => {
+        const active = ctx.get();
+        expect(active.headers.get('cookie')).toBe('foo=bar');
+        expect(active.tenantId).toBe('ext-tenant');
+      });
+    });
+
+    const withContextCalls = runExtensionsMock.mock.calls.filter(
+      ([state]) => state === ExtensionState.withContext
+    );
+    expect(withContextCalls).toHaveLength(1);
+  });
+});

--- a/packages/server/src/api/utils/request.ts
+++ b/packages/server/src/api/utils/request.ts
@@ -1,4 +1,3 @@
-import { parseCallback } from '../../auth';
 import { ExtensionState } from '../../types';
 import {
   HEADER_ORIGIN,
@@ -15,7 +14,7 @@ export default async function request(
   _init: RequestInit & { request: Request },
   config: Config
 ) {
-  const { debug, info, error, warn } = config.logger('[REQUEST]');
+  const { debug, info, error } = config.logger('[REQUEST]');
   const { request, ...init } = _init;
   const requestUrl = new URL(request.url);
   const updatedHeaders = new Headers({});

--- a/packages/server/src/auth/index.ts
+++ b/packages/server/src/auth/index.ts
@@ -129,24 +129,28 @@ export default class Auth {
    * from the internal configuration once the request completes.
    */
   async signOut(): Promise<Response> {
-    return withNileContext(this.#config, async () => {
-      // check for csrf header, maybe its already there?
-      const csrfRes = await this.getCsrf();
-      if (!('csrfToken' in csrfRes)) {
-        throw new Error('Unable to obtain CSRF token. Sign out failed.');
-      }
+    return withNileContext(
+      this.#config,
+      async () => {
+        // check for csrf header, maybe its already there?
+        const csrfRes = await this.getCsrf();
+        if (!('csrfToken' in csrfRes)) {
+          throw new Error('Unable to obtain CSRF token. Sign out failed.');
+        }
 
-      const body = JSON.stringify({
-        csrfToken: csrfRes.csrfToken,
-        json: true,
-      });
-      const res = await fetchSignOut(this.#config, body);
+        const body = JSON.stringify({
+          csrfToken: csrfRes.csrfToken,
+          json: true,
+        });
+        const res = await fetchSignOut(this.#config, body);
 
-      updateHeaders(new Headers({}));
-      ctx.set({ headers: null });
+        updateHeaders(new Headers({}));
+        ctx.set({ headers: null });
 
-      return res;
-    });
+        return res;
+      },
+      'signout'
+    );
   }
 
   /**
@@ -168,72 +172,78 @@ export default class Auth {
     payload: SignUpPayload,
     rawResponse?: boolean
   ): Promise<T> {
-    return withNileContext(this.#config, async () => {
-      // be sure its fresh
-      ctx.set({ headers: null });
-      const { email, password, ...params } = payload;
-      if (!email || !password) {
-        throw new Error(
-          'Server side sign up requires a user email and password.'
-        );
-      }
-
-      const providers = await this.listProviders();
-      const { credentials } = providers ?? {};
-      if (!credentials) {
-        throw new Error(
-          'Unable to obtain credential provider. Aborting server side sign up.'
-        );
-      }
-
-      const csrf = await obtainCsrf(this.#config);
-
-      let csrfToken;
-      if ('csrfToken' in csrf) {
-        csrfToken = csrf.csrfToken;
-      } else {
-        throw new Error('Unable to obtain parse CSRF. Request blocked.');
-      }
-
-      const body = JSON.stringify({
-        email,
-        password,
-        csrfToken,
-        callbackUrl: credentials.callbackUrl,
-      });
-
-      const res = await fetchSignUp(this.#config, { body, params });
-      if (res.status > 299) {
-        this.#logger.error(await res.clone().text());
-        return undefined as T;
-      }
-      const token = parseToken(res.headers);
-      if (!token) {
-        throw new Error('Server side sign up failed. Session token not found');
-      }
-      const { headers } = ctx.get();
-      headers?.append('cookie', token);
-      ctx.set({ headers });
-      // this will globally set headers for everyone, so how
-      // do you make it so you can chain these together? or at least
-      // call them sequentially safely? you gotta use the `withContext` callback
-      updateHeaders(headers);
-      if (rawResponse) {
-        return res as T;
-      }
-      try {
-        const json = (await res.clone().json()) as T;
-        if (json && typeof json === 'object' && 'tenants' in json) {
-          const tenantId = (json as unknown as User).tenants[0];
-          if (tenantId) {
-            updateTenantId(tenantId);
-          }
+    return withNileContext(
+      this.#config,
+      async () => {
+        // be sure its fresh
+        ctx.set({ headers: null });
+        const { email, password, ...params } = payload;
+        if (!email || !password) {
+          throw new Error(
+            'Server side sign up requires a user email and password.'
+          );
         }
-        return json;
-      } catch {
-        return res as T;
-      }
-    });
+
+        const providers = await this.listProviders();
+        const { credentials } = providers ?? {};
+        if (!credentials) {
+          throw new Error(
+            'Unable to obtain credential provider. Aborting server side sign up.'
+          );
+        }
+
+        const csrf = await obtainCsrf(this.#config);
+
+        let csrfToken;
+        if ('csrfToken' in csrf) {
+          csrfToken = csrf.csrfToken;
+        } else {
+          throw new Error('Unable to obtain parse CSRF. Request blocked.');
+        }
+
+        const body = JSON.stringify({
+          email,
+          password,
+          csrfToken,
+          callbackUrl: credentials.callbackUrl,
+        });
+
+        const res = await fetchSignUp(this.#config, { body, params });
+        if (res.status > 299) {
+          this.#logger.error(await res.clone().text());
+          return undefined as T;
+        }
+        const token = parseToken(res.headers);
+        if (!token) {
+          throw new Error(
+            'Server side sign up failed. Session token not found'
+          );
+        }
+        const { headers } = ctx.get();
+        headers?.append('cookie', token);
+        ctx.set({ headers });
+        // this will globally set headers for everyone, so how
+        // do you make it so you can chain these together? or at least
+        // call them sequentially safely? you gotta use the `withContext` callback
+        updateHeaders(headers);
+        if (rawResponse) {
+          return res as T;
+        }
+        try {
+          const json = (await res.clone().json()) as T;
+          if (json && typeof json === 'object' && 'tenants' in json) {
+            const tenantId = (json as unknown as User).tenants[0];
+            if (tenantId) {
+              updateTenantId(tenantId);
+            }
+          }
+          return json;
+        } catch {
+          return res as T;
+        }
+      },
+      'signup'
+    );
   }
 
   /**

--- a/packages/server/src/users/index.ts
+++ b/packages/server/src/users/index.ts
@@ -91,18 +91,22 @@ export default class Users {
   async getSelf<T = User | Response>(rawResponse?: false): Promise<T>;
   async getSelf(rawResponse: true): Promise<Response>;
   async getSelf<T = User | Response>(rawResponse?: boolean): Promise<T> {
-    return withNileContext(this.#config, async () => {
-      const res = await fetchMe(this.#config);
+    return withNileContext(
+      this.#config,
+      async () => {
+        const res = await fetchMe(this.#config);
 
-      if (rawResponse) {
-        return res as T;
-      }
-      try {
-        return await res?.clone().json();
-      } catch {
-        return res as T;
-      }
-    });
+        if (rawResponse) {
+          return res as T;
+        }
+        try {
+          return await res?.clone().json();
+        } catch {
+          return res as T;
+        }
+      },
+      'getSelf'
+    );
   }
 
   /**


### PR DESCRIPTION
found a cool bug that doesn't sync headers based on API vs server side. Maybe only nextjs has this problem, but now no one does.