### PR TITLE
updated publish config for elysia package

### DIFF
--- a/packages/elysia/package.json
+++ b/packages/elysia/package.json
@@ -22,6 +22,14 @@
     "@niledatabase/server": ">=5.2.0",
     "elysia": ">=1.0.0"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/niledatabase/nile-js.git",
+    "directory": "packages/elysia"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
   "devDependencies": {
     "@elysiajs/node": "^1.4.2",
     "@niledatabase/server": "workspace:^",


### PR DESCRIPTION
`@niledatabase/elysia` is not published on NPM or it might be private as of now, updated publish config in `@niledatabase/elysia` package to fix the issue. 