### PR TITLE
fix: disabled elysia body parser for nile paths

### DIFF
--- a/packages/elysia/src/index.ts
+++ b/packages/elysia/src/index.ts
@@ -21,9 +21,7 @@ export const elysia = (app: Elysia): Extension => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const handlers = instance.handlers as any;
 
-      paths.get.forEach((path) => app.get(path, handlers.GET), {
-        parse: "none",
-      });
+      paths.get.forEach((path) => app.get(path, handlers.GET));
       paths.post.forEach((path) => app.post(path, handlers.POST), {
         parse: "none",
       });


### PR DESCRIPTION
when I hit `api/*` nile auth paths with elysia extensions I get this error: 

```
[niledb][ERROR][REQUEST] Failed to parse request body
[niledb][ERROR][REQUEST] An error has occurred in the fetch {
  message: "ReadableStream has already been used",
  stack: "Error: ReadableStream has already been used\n    at fetch (unknown)\n    at request (/Users/michio/dev/personal/hawalah/app/node_modules/@niledatabase/server/dist/index.mjs:606:23)\n    at processTicksAndRejections (native:7:39)",
```

I think it's related to default body parser in elysia